### PR TITLE
Added preferred tags for flows

### DIFF
--- a/etc/create_sample_job.py
+++ b/etc/create_sample_job.py
@@ -9,6 +9,10 @@ job = {
     "cluster_id": "49fa2adde8a6e98591f0f5cb4bc5f44d",
     "run": "tendrl.gluster_integration.flows.create_volume.CreateVolume",
     "status": 'new',
+    "targeted_tags": [  # Refer flow definition file for details about this
+        "tendrl/integration/gluster",
+        "gluster/server"
+    ],
     "parameters": {
         "Volume.volname": 'Volume1',
         "Volume.bricks": ["mntpath1", "mntpath2"]

--- a/tendrl/gluster_integration/manager/tendrl_definitions_gluster.py
+++ b/tendrl/gluster_integration/manager/tendrl_definitions_gluster.py
@@ -6,6 +6,9 @@ namespace.tendrl.gluster_integration:
       atoms:
         - tendrl.gluster_integration.objects.Volume.atoms.create
       help: "Create Volume with bricks"
+      preferred_tags:
+        - "tendrl/integration/gluster"
+        - "gluster/server"
       enabled: true
       inputs:
         mandatory:
@@ -148,6 +151,9 @@ namespace.tendrl.gluster_integration:
           atoms:
             - tendrl.gluster_integration.objects.Volume.atoms.delete
           help: "Delete Volume"
+          preferred_tags:
+            - "tendrl/integration/gluster"
+            - "gluster/server"
           enabled: true
           inputs:
             mandatory:
@@ -165,6 +171,9 @@ namespace.tendrl.gluster_integration:
           atoms:
             - tendrl.gluster_integration.objects.Volume.atoms.start
           help: "Start Volume"
+          preferred_tags:
+            - "tendrl/integration/gluster"
+            - "gluster/server"
           enabled: true
           inputs:
             mandatory:
@@ -181,6 +190,9 @@ namespace.tendrl.gluster_integration:
           atoms:
             - tendrl.gluster_integration.objects.Volume.atoms.stop
           help: "Stop Volume"
+          preferred_tags:
+            - "tendrl/integration/gluster"
+            - "gluster/server"
           enabled: true
           inputs:
             mandatory:


### PR DESCRIPTION
This patch adds preferred tags to be used for flows
related to node-agent. The jobs that are created for
this flows must use the "preffered_tags" in flow for
adding field "targeted_tags" field in the job. These
jobs will be picked only by nodes having the specified
tags

tendrl-bug-id:Tendrl/gluster_integration#113
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>