### PR TITLE
Fix service start issue due to environment variable issue

### DIFF
--- a/tendrl-glusterd.service
+++ b/tendrl-glusterd.service
@@ -3,6 +3,7 @@ Description=Tendrl Gluster Daemon to Manage gluster tasks
 
 [Service]
 Type=simple
+Environment="HOME=/var/lib/tendrl"
 ExecStart=/usr/bin/tendrl-gluster-integration
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process


### PR DESCRIPTION
Set the HOME variable path to /var/lib/tendrl

tendrl-bug-id: Tendrl/gluster-integration#131
Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>