### PR TITLE
WIP: Tendrl-gdeploy wrapper for gluster provisoning

### DIFF
--- a/tendrl/gluster_integration/gdeploy/atoms/create_gluster_volume.py
+++ b/tendrl/gluster_integration/gdeploy/atoms/create_gluster_volume.py
@@ -1,0 +1,60 @@
+from gdeploy_features import *
+from gdeploy_utils import cook_gdeploy_config
+from gdeploy_utils import invoke_gdeploy
+
+
+def create_volume(volume_name, brick_details, transport=[],
+                  replica_count="", force=False):
+    """
+    Brick details should be of following form
+    [
+      {"hostname2": ["brick1","brick2"]},
+      {"hostname3": ["brick1","brick2"]},
+      {"hostname1": ["brick1","brick2"]},
+    ]
+    """
+    recipe = []
+    brick_list = []
+    host_list = []
+    for host in brick_details:
+        host_list.append(host.keys()[0])
+        for brick in host.values()[0]:
+            brick_list.append(host.keys()[0] + ":" + brick)
+    recipe.append(get_hosts(host_list))
+
+    recipe.append(
+        get_volume(
+            volume_name,
+            "create",
+            brick_dirs=brick_list,
+            transport=transport,
+            replica_count=replica_count,
+            force=force
+        )
+    )
+
+    print recipe
+
+    config_str = cook_gdeploy_config(recipe)
+
+    print config_str
+    out , err, rc = invoke_gdeploy(config_str)
+    print out, err, rc
+
+volume_name="tendrl_vol1"
+"""
+brick_details = [
+    {"hostname2": ["brick1","brick2"]},
+    {"hostname3": ["brick1","brick2"]},
+    {"hostname1": ["brick1","brick2"]},
+]
+"""
+brick_details = [
+    {"10.70.43.136": ["/mnt/tendrl_vol1_b1","/mnt/tendrl_vol1_b2"]},
+    {"10.70.42.40": ["/mnt/tendrl_vol1_b3","/mnt/tendrl_vol1_b4"]},
+]
+
+transport = ["tcp"]
+replicacount = 2
+force=True
+create_volume(volume_name,brick_details,transport,replicacount,force)

--- a/tendrl/gluster_integration/gdeploy/atoms/expand_gluster_volume.py
+++ b/tendrl/gluster_integration/gdeploy/atoms/expand_gluster_volume.py
@@ -1,0 +1,57 @@
+from gdeploy_features import *
+from gdeploy_utils import cook_gdeploy_config
+from gdeploy_utils import invoke_gdeploy
+
+
+def expand_volume(volume_name, brick_details, replica_count="",
+                  force=False):
+    """
+    Brick details should be of following form
+    [
+      {"hostname2": ["brick1","brick2"]},
+      {"hostname3": ["brick1","brick2"]},
+      {"hostname1": ["brick1","brick2"]},
+    ]
+    """
+    recipe = []
+    brick_list = []
+    host_list = []
+    for host in brick_details:
+        host_list.append(host.keys()[0])
+        for brick in host.values()[0]:
+            brick_list.append(host.keys()[0] + ":" + brick)
+    recipe.append(get_hosts(host_list))
+
+    recipe.append(
+        get_volume(
+            volume_name,
+            "add-brick",
+            brick_dirs=brick_list,
+            replica_count=replica_count,
+            force=force
+        )
+    )
+
+    print recipe
+
+    config_str = cook_gdeploy_config(recipe)
+
+    print config_str
+    out , err, rc = invoke_gdeploy(config_str)
+    print out, err, rc
+
+volume_name="tendrl_vol1"
+"""
+brick_details = [
+    {"hostname2": ["brick1","brick2"]},
+    {"hostname3": ["brick1","brick2"]},
+    {"hostname1": ["brick1","brick2"]},
+]
+"""
+brick_details = [
+    {"10.70.42.40": ["/mnt/vol1_Expand_b3","/mnt/tendrl_vol1_Expand_b4"]},
+]
+
+#replicacount = 2
+force=True
+expand_volume(volume_name,brick_details,force=force)

--- a/tendrl/gluster_integration/gdeploy/atoms/gluster_brick_provision.py
+++ b/tendrl/gluster_integration/gdeploy/atoms/gluster_brick_provision.py
@@ -1,0 +1,121 @@
+from gdeploy_features import *
+from gdeploy_utils import cook_gdeploy_config
+from gdeploy_utils import invoke_gdeploy
+
+
+def provision_disks(disk_dictionary):
+    """Structure of disk dictionary
+    
+    {"host_name_0": {
+           "diks_name_0": {
+                   "mount_path": <actual-mountpath>,
+                   "brick_path": <actual-brick-path>
+           },
+           "diks_name_1": {
+                   "mount_path": <actual-mountpath>,
+                   "brick_path": <actual-brick-path>
+           },
+           "diks_name_2": {
+                   "mount_path": <actual-mountpath>,
+                   "brick_path": <actual-brick-path>
+           }
+     },
+    "host_name_2": {
+           "diks_name_0": {
+                   "mount_path": <actual-mountpath>,
+                   "brick_path": <actual-brick-path>
+           },
+           "diks_name_1": {
+                   "mount_path": <actual-mountpath>,
+                   "brick_path": <actual-brick-path>
+           },
+           "diks_name_2": {
+                   "mount_path": <actual-mountpath>,
+                   "brick_path": <actual-brick-path>
+           },
+     }
+    }
+    """
+    recipe = []
+    recipe.append(get_hosts(disk_dictionary.keys()))
+    for host, disks in disk_dictionary.iteritems():
+        device_list = []
+        mount_point_list = []
+        brick_path_list = []
+        for disk, detail in disks.iteritems():
+            device_list.append(disk)
+            mount_point_list.append(detail["mount_path"])
+            brick_path_list.append(detail["brick_path"])
+        recipe.append(
+            get_backend_setup(
+                device_list,
+                mount_points=mount_point_list,
+                brick_dirs=brick_path_list,
+                target_host=host
+            )
+        )
+
+    print recipe
+
+    config_str = cook_gdeploy_config(recipe)
+
+    print config_str
+    out , err, rc = invoke_gdeploy(config_str)
+    print out, err, rc
+
+"""
+d = {
+    "10.70.23.23" : {
+        "vda": {
+            "mount_path": "/mnt/tendrl_b1",
+            "brick_path": "/mnt/tendrl_b1/b1",
+        },
+        "vdb": {
+            "mount_path": "/mnt/tendrl_b2",
+            "brick_path": "/mnt/tendrl_b2/b2",
+        },
+        "vdc": {
+            "mount_path": "/mnt/tendrl_b3",
+            "brick_path": "/mnt/tendrl_b3/b3",
+        },
+    },
+    "10.70.24.456" : {
+        "vda": {
+            "mount_path": "/mnt/tendrl_b1",
+            "brick_path": "/mnt/tendrl_b1/b1",
+        },
+        "vdb": {
+            "mount_path": "/mnt/tendrl_b2",
+            "brick_path": "/mnt/tendrl_b2/b2",
+        },
+        "vdc": {
+            "mount_path": "/mnt/tendrl_b3",
+            "brick_path": "/mnt/tendrl_b3/b3",
+        },
+    },
+    "10.70.28.211" : {
+        "vda": {
+            "mount_path": "/mnt/tendrl_b1",
+            "brick_path": "/mnt/tendrl_b1/b1",
+        },
+        "vdb": {
+            "mount_path": "/mnt/tendrl_b2",
+            "brick_path": "/mnt/tendrl_b2/b2",
+        },
+        "vdc": {
+            "mount_path": "/mnt/tendrl_b3",
+            "brick_path": "/mnt/tendrl_b3/b3",
+        },
+    }
+}
+
+"""
+d = {
+    "10.70.42.40" : {
+        "vdb": {
+            "mount_path": "/mnt/tendrl_b1",
+            "brick_path": "/mnt/tendrl_b1/b1",
+        },
+    }
+}
+provision_disks(d)

--- a/tendrl/gluster_integration/gdeploy/atoms/gluster_package_installation.py
+++ b/tendrl/gluster_integration/gdeploy/atoms/gluster_package_installation.py
@@ -1,0 +1,34 @@
+from tendrl.gluster_integration.gdeploy.gdeploy_features import *
+from tendrl.gluster_integration.gdeploy.gdeploy_utils import cook_gdeploy_config
+from tendrl.gluster_integration.gdeploy.gdeploy_utils import invoke_gdeploy
+
+GLUSTERFS_PACKAGES = [
+    "glusterfs",
+    "glusterfs-server",
+    "glusterfs-cli",
+    "glusterfs-libs",
+    "glusterfs-client-xlators",
+    "glusterfs-api",
+    "glusterfs-fuse"
+]
+
+GLUSTERFS_REPO = "https://buildlogs.centos.org/centos/7/storage/x86_64/gluster-3.9/"
+
+
+def gluster_package_installation(host_list, glusterfs_packages=None, glusterfs_repo=None, gpgcheck=None):
+    recipe = []
+
+    recipe.append(get_hosts(host_list))
+    
+    recipe.append(
+        get_yum(
+            "install",
+            glusterfs_packages if glusterfs_packages else GLUSTERFS_PACKAGES,
+            glusterfs_repo if glusterfs_repo else GLUSTERFS_REPO,
+            gpgcheck if gpgcheck else "no"
+        )
+    )
+
+    config_str = cook_gdeploy_config(recipe)
+
+    return invoke_gdeploy(config_str)

--- a/tendrl/gluster_integration/gdeploy/atoms/set_volume_options.py
+++ b/tendrl/gluster_integration/gdeploy/atoms/set_volume_options.py
@@ -1,0 +1,53 @@
+from gdeploy_features import *
+from gdeploy_utils import cook_gdeploy_config
+from gdeploy_utils import invoke_gdeploy
+
+
+def set_volume_options(volume_name, hostname, options):
+    """
+    options should be of following form
+    [
+      {"option2": "Value2"},
+      {"option3": "Value3"},
+      {"option1": "Value1"},
+    ]
+    """
+    recipe = []
+    option_key_list = []
+    option_value_list = []
+    for option in options:
+        option_key_list.append(option.keys()[0])
+        option_value_list.append(option.values()[0])
+    host_vol = hostname + ":" + volume_name
+    recipe.append(
+        get_volume(
+            host_vol,
+            "set",
+            option_keys=option_key_list,
+            option_values=option_value_list
+        )
+    )
+
+    print recipe
+
+    config_str = cook_gdeploy_config(recipe)
+
+    print config_str
+    out , err, rc = invoke_gdeploy(config_str)
+    print out, err, rc
+
+volume_name="tendrl_vol1"
+hostname="10.70.42.40"
+"""
+options = [
+    {"key1": "value1"},
+    {"key2": "value2"},
+    {"key3": "value3"},
+    {"key4": "value4"},
+]
+"""
+options = [
+    {"features.ctr_lookupheal_link_timeout": "302"},
+    {"features.ctr_lookupheal_inode_timeout": "301"},
+]
+set_volume_options(volume_name, hostname, options)

--- a/tendrl/gluster_integration/gdeploy/atoms/snapshot_config.py
+++ b/tendrl/gluster_integration/gdeploy/atoms/snapshot_config.py
@@ -1,0 +1,29 @@
+from gdeploy_features import *
+from gdeploy_utils import cook_gdeploy_config
+from gdeploy_utils import invoke_gdeploy
+
+
+def volume_snapshot_config(volume_name, hostname, action, snapname=""):
+    recipe = []
+    host_vol = hostname + ":" + volume_name
+    recipe.append(
+        get_snapshot(
+            host_vol,
+            action,
+            snapname
+        )
+    )
+
+    print recipe
+
+    config_str = cook_gdeploy_config(recipe)
+
+    print config_str
+    out , err, rc = invoke_gdeploy(config_str)
+    print out, err, rc
+
+volume_name="snap"
+hostname="10.70.42.40"
+action="delete"
+snapname = "snap1"
+volume_snapshot_config(volume_name, hostname, action, snapname)

--- a/tendrl/gluster_integration/gdeploy/atoms/volume_quota_config.py
+++ b/tendrl/gluster_integration/gdeploy/atoms/volume_quota_config.py
@@ -1,0 +1,65 @@
+from gdeploy_features import *
+from gdeploy_utils import cook_gdeploy_config
+from gdeploy_utils import invoke_gdeploy
+
+
+def volume_quota_config(volume_name, hostname, action, dir_details={}):
+    """
+    dir_details should be of following form
+    [
+      {"dir2": "size2"},
+      {"dir1": "size1"},
+      {"dir3": "size3"},
+    ]
+    """
+    recipe = []
+    host_vol = hostname + ":" + volume_name
+    if dir_details:
+        dir_list = []
+        size_list = []
+        for directory in dir_details:
+            dir_list.append(directory.keys()[0])
+            size_list.append(directory.values()[0])
+        recipe.append(
+            get_quota(
+                host_vol,
+                action,
+                path=dir_list,
+                size=size_list
+            )
+        )
+    else:
+        recipe.append(
+            get_quota(
+                host_vol,
+                action
+            )
+        )
+
+    print recipe
+
+    config_str = cook_gdeploy_config(recipe)
+
+    print config_str
+    out , err, rc = invoke_gdeploy(config_str)
+    print out, err, rc
+
+volume_name="snap"
+hostname="10.70.42.40"
+"""
+dir_details = [
+    {"dir1": "size1"},
+    {"dir2": "size2"},
+    {"dir3": "size3"},
+    {"dir4": "size4"},
+]
+"""
+dir_details = [
+    {"DIR1": "5MB"},
+    {"DIR2": "5MB"},
+]
+
+action="limit-usage"
+#action="enable"
+volume_quota_config(volume_name, hostname,action,dir_details)
+#volume_quota_config(volume_name, hostname, action)

--- a/tendrl/gluster_integration/gdeploy/gdeploy_features.py
+++ b/tendrl/gluster_integration/gdeploy/gdeploy_features.py
@@ -1,0 +1,128 @@
+def get_hosts(host_list):
+    host = {
+        "hosts": host_list
+    }
+    return host
+
+def get_yum(action, packages, repos=None, gpgcheck="yes", update="no", target_host=""):
+    yum = {
+        "action": action,
+        "packages": packages,
+    }
+
+    if action == "install":
+        yum.update(
+            {
+                "gpgcheck": gpgcheck,
+                "update": update
+            }
+        )
+        if repos:
+            yum.update(
+                {"repos": repos}
+            )
+    section_header = "yum"
+    if target_host:
+        section_header += ":" + target_host
+    return {section_header: yum}
+
+def get_backend_setup(devices, vgs=None, pools=None, lvs=None,
+                      lv_size=None, mount_points=None,
+                      brick_dirs=None, target_host=""):
+    backend_setup = {
+        "devices": devices
+    }
+    if vgs:
+        backend_setup.update(
+            {"vgs": vgs}
+        )
+    if lvs:
+        backend_setup.update(
+            {"lvs": lvs}
+        )
+    if pools:
+        backend_setup.update(
+            {"pools": pools}
+        )
+    if lv_size:
+        backend_setup.update(
+            {"size": lv_size}
+        )
+    if mount_points:
+        backend_setup.update(
+            {"mountpoints": mount_points}
+        )
+    if brick_dirs:
+        backend_setup.update(
+            {"brick_dirs": brick_dirs}
+        )
+    section_header = "backend-setup"
+    if target_host:
+        section_header += ":" + target_host
+    return {section_header: backend_setup}
+
+def get_volume(volume_name, action, brick_dirs=None, transport=None,
+               replica_count=None, disperse=None, disperse_count=None,
+               redundancy_count=None, force="", target_host="",
+               option_keys=[], option_values=[]):
+    volume = {
+        "volname": volume_name,
+        "action": action
+    }
+    if brick_dirs:
+        if action == "add-brick":
+            volume.update({"bricks": brick_dirs})
+        else:
+            volume.update({"brick_dirs": brick_dirs})
+    if transport:
+        volume.update({"transport": transport})
+    if replica_count:
+        volume.update({"replica_count": replica_count})
+    if disperse_count:
+        volume.update({"disperse_count": disperse_count})
+    if disperse:
+        volume.update({"disperse": disperse})
+    if redundancy_count:
+        volume.update({"redundancy_count": redundancy_count})
+    if force != "":
+        volume.update({"force": "yes" if force else "no"})
+    if option_keys:
+        volume.update({"key": option_keys})
+    if option_values:
+        volume.update({"value": option_values})
+
+
+    section_header = "volume"
+    if target_host:
+        section_header += ":" + target_host
+    return {section_header: volume}
+
+def get_snapshot(volume_name, action, snap_name, target_host=""):
+    snapshot = {
+        "action": action,
+        "volname": volume_name,
+        "snap_name": snap_name
+    }
+    
+    section_header = "snapshot"
+    if target_host:
+        section_header += ":" + target_host
+    return {section_header: snapshot}
+
+def get_quota(volume_name, action, path=[], size=[], target_host=""):
+    quota = {
+        "volname": volume_name,
+        "action": action
+    }
+    if path:
+        quota.update(
+            {
+                "path": path,
+                "size": size
+            }
+        )
+
+    section_header = "quota"
+    if target_host:
+        section_header += ":" + target_host
+    return {section_header: quota}

--- a/tendrl/gluster_integration/gdeploy/gdeploy_utils.py
+++ b/tendrl/gluster_integration/gdeploy/gdeploy_utils.py
@@ -1,0 +1,41 @@
+import os
+import uuid
+
+from tendrl.commons.utils import cmd_utils
+
+GDEPLOY_CONFIG_PATH = "/var/run/tendrl/gdeploy/config_"
+
+def add_section(section):
+    return "[" + section + "]\n"
+
+def cook_gdeploy_config(recipe):
+    config_str = ""
+    for el in recipe:
+        k = el.keys()[0]
+        v = el.values()[0]
+        config_str += add_section(k)
+        if type(v) == list:
+            for el in v:
+                config_str += el + "\n"
+        elif type(v) == dict:
+            for var, val in v.iteritems():
+                if val == None:
+                    line = val
+                    continue
+                line = var + "=" + (str(val) if type(val) != list else ",".join(val))
+                config_str += line + "\n"
+        config_str += "\n"
+
+    return config_str
+                
+def invoke_gdeploy(config):
+    conf_file = GDEPLOY_CONFIG_PATH + str(uuid.uuid4()) + ".conf"
+    with open(conf_file, 'w') as f:
+        f.write(config)
+    cmd = cmd_utils.Command("gdeploy -c " + conf_file)
+    # to be changed to correct path
+    out, err, rc = cmd.run("/var/run/tendrl/tendrl_exe")
+    os.remove(conf_file)
+    return out, err, rc
+    
+    


### PR DESCRIPTION
This patch adds a wrapper for gdeploy, which can be used to
generate gdeploy config files and further execute them to
get the desired gluster provisoning tasks done. Also
this patch adds atoms for:
* gluster package installation
* gluster brick provison
* gluster volume creation
* volume option configuration
* snapshot configuration
* quota configuration
* gluster volume expansion

NOTE: the comments are left in the code for easy
review.

Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>