### PR TITLE
Have a field for cluster name under tendrl-context.

### DIFF
--- a/tendrl/gluster_integration/objects/tendrl_context/__init__.py
+++ b/tendrl/gluster_integration/objects/tendrl_context/__init__.py
@@ -18,6 +18,7 @@ class TendrlContext(objects.GlusterIntegrationBaseObject):
         # integration_id is the Tendrl generated cluster UUID
         self.integration_id = integration_id or self._get_local_integration_id()
         self.sds_name, self.sds_version = self._get_sds_details()
+        self.integration_name = self.sds_name + "_" + self.integration_id
         self._etcd_cls = _TendrlContextEtcd
 
     def create_local_integration_id(self):


### PR DESCRIPTION
We should have a field called integration name under
TendrlContext object to indicate cluster name. Since
glusterfs backend does not have a concept of cluster
name, its generated using integration_id as follows:
"glusterfs_<integration-id>" whaere integration_id is
tendrl generated cluster id.

tendrl-bug-id: Tendrl/gluster-integration#143
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>