### PR TITLE
Added import for `os` as it was removed as a regression

### DIFF
--- a/tendrl/gluster_integration/sds_sync/__init__.py
+++ b/tendrl/gluster_integration/sds_sync/__init__.py
@@ -1,5 +1,6 @@
 import gevent
 import json
+import os
 import re
 import subprocess
 


### PR DESCRIPTION
Due to this cluster status and volume utlization details
were not being synced while regular sync.

tendrl-bug-id: Tendrl/gluster-integration#217
Signed-off-by: Shubhendu <shtripat@redhat.com>