### PR TITLE
Added check for proper output of gstatus

### DIFF
--- a/tendrl/gluster_integration/sds_sync/__init__.py
+++ b/tendrl/gluster_integration/sds_sync/__init__.py
@@ -334,8 +334,10 @@ class GlusterIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
                     out_lines = stdout.split('\n')
                     connected = True
                     for index in range(4, len(out_lines) - 2):
-                        if out_lines[index].split('\t')[2].strip() != 'Connected':
-                            connected = connected and False
+                        node_status_det = out_lines[index].split('\t')
+                        if len(node_status_det) > 2:
+                            if node_status_det[2].strip() != 'Connected':
+                                connected = connected and False
                     if connected:
                         NS.gluster.objects.GlobalDetails(
                             status='healthy'


### PR DESCRIPTION
Make sure default status update doesnt fail with exception
even if gstatus return bogus data.

tendrl-bug-id: Tendrl/gluster-integration#245
Signed-off-by: Shubhendu <shtripat@redhat.com>