### PR TITLE
Classify bricks gluster bricks as used/free

### DIFF
--- a/tendrl/gluster_integration/flows/create_brick/__init__.py
+++ b/tendrl/gluster_integration/flows/create_brick/__init__.py
@@ -3,7 +3,7 @@ from tendrl.commons.event import Event
 from tendrl.commons.message import Message
 
 
-class CreateGlusterBrick(flows.BaseFlow):
+class CreateBrick(flows.BaseFlow):
     def run(self):
         Event(
             Message(
@@ -18,4 +18,4 @@ class CreateGlusterBrick(flows.BaseFlow):
             )
         )
 
-        super(CreateGlusterBrick, self).run()
+        super(CreateBrick, self).run()

--- a/tendrl/gluster_integration/objects/definition/gluster.yaml
+++ b/tendrl/gluster_integration/objects/definition/gluster.yaml
@@ -24,7 +24,9 @@ namespace.gluster:
       type: Create
       uuid: 1951e821-7aa9-4a91-8183-e73bc8275b8e
       version: 1
-    CreateGlusterBrick:
+    CreateBrick:
+      tags:
+       - "provisioner/$TendrlContext.integration_id"
       atoms:
         - tendrl.gluster.objects.GlusterBrick.atoms.Create
       help: "Create gluster bricks that can be used by volumes"
@@ -36,7 +38,7 @@ namespace.gluster:
           - GlusterBrick.disk_type
           - GlusterBrick.disk_count
           - GlusterBrick.stripe_size
-      run: tendrl.gluster.flows.CreateGlusterBrick
+      run: tendrl.gluster.flows.CreateBrick
       type: Create
       uuid: 1951e821-7aa9-4a91-8183-e73bc8275b8d
       version: 1
@@ -59,6 +61,14 @@ namespace.gluster:
       list: clusters/$TendrlContext.integration_id/GlobalDetails
       value: clusters/$TendrlContext.integration_id/GlobalDetails
       help: Clustr global details
+    GlusterBrickDir:
+      attrs:
+        default_brick_dir:
+          help: gives the default brick directory
+          type: String
+      enabled: true
+      value: clusters/$TendrlContext.integration_id/GlusterBrickDir
+      help: directory of gluster bricks
     Utilization:
       attrs:
         raw_capacity:
@@ -166,7 +176,7 @@ namespace.gluster:
               - GlusterBrick.disk_type
               - GlusterBrick.disk_count
               - GlusterBrick.stripe_size
-          name: create_gluster_brick
+          name: create_brick
           run: tendrl.gluster.objects.GlusterBrick.atoms.Create
           type: Create
           uuid: 242f6190-9b37-11e6-950d-a24fc0d9649d
@@ -180,6 +190,9 @@ namespace.gluster:
           type: String
         node_id:
           help: node_id of the node on which brick recides
+          type: String
+        volume_name:
+          help: volume_name of the volume to which brick belongs
           type: String
         mount_path:
           help: mount point of the brick
@@ -210,7 +223,7 @@ namespace.gluster:
           type: String
       enabled: true
       value: clusters/$TendrlContext.integration_id/nodes/$TendrlContext.node_id/GlusterBricks/$GlusterBrick.brick_name
-      list:  clusters/$TendrlContext.integration_id/nodes/$TendrlContext.node_id/GlusterBricks/
+      list:  clusters/$TendrlContext.integration_id/nodes/$TendrlContext.node_id/GlusterBricks/all
       help: gluster bricks that can be used for gluster volumes
     Volume:
       atoms:
@@ -238,8 +251,6 @@ namespace.gluster:
             mandatory:
               - Volume.volname
               - Volume.vol_id
-            optional:
-              - Volume.format_bricks
           name: delete_volume
           run: gluster.objects.Volume.atoms.Delete
           type: Delete
@@ -441,8 +452,6 @@ namespace.gluster:
             mandatory:
               - Volume.volname
               - Volume.vol_id
-            optional:
-              - Volume.format_bricks
           post_run:
             - gluster.objects.Volume.atoms.VolumeNotExists
           pre_run:
@@ -579,18 +588,27 @@ namespace.gluster:
         bricks:
           help: "List of brick mnt_paths for volume"
           type: List
+        fix_layout:
+          help: "Whether the volume layout has to be fixed after rebalance"
+          type: Boolean
         deleted:
           help: "Flag is volume is deleted"
           type: Boolean
         disperse_count:
           help: "Disperse count of volume"
           type: Integer
+        tuned_profile:
+          help: "The tuning profile the volume"
+          type: String
         disperse_data_count:
           help: "Disperse data count of volume"
           type: Integer
         force:
           help: "If force execute the action"
           type: Boolean
+        action:
+          help: "action that has to be performed on volume"
+          type: String
         redundancy_count:
           help: "Redundancy count of volume"
           type: Integer

--- a/tendrl/gluster_integration/objects/gluster_brick/__init__.py
+++ b/tendrl/gluster_integration/objects/gluster_brick/__init__.py
@@ -20,6 +20,7 @@ class GlusterBrick(objects.BaseObject):
         disk_type=None,
         disk_count=None,
         stripe_size=None,
+        volume_name=None,
         *args,
         **kwargs
     ):
@@ -36,8 +37,9 @@ class GlusterBrick(objects.BaseObject):
         self.vg = vg
         self.pool = pool
         self.pv = pv
+        self.volume_name = volume_name if volume_name else ""
         self.stripe_size = stripe_size
-        self.value = 'clusters/{0}/nodes/{1}/GlusterBricks/{2}'
+        self.value = 'clusters/{0}/nodes/{1}/GlusterBricks/all/{2}'
 
     def render(self):
         self.value = self.value.format(NS.tendrl_context.integration_id,

--- a/tendrl/gluster_integration/objects/gluster_brick/atoms/create/__init__.py
+++ b/tendrl/gluster_integration/objects/gluster_brick/atoms/create/__init__.py
@@ -18,17 +18,18 @@ class Create(objects.BaseAtom):
             host = NS._int.client.read(key).value
             brick_dict[host] = {}
             for dev_name, details in v.iteritems():
+                dev = dev_name.split("/")[-1]
                 mount_path = brick_prefix + "/" + details["brick_name"] + "_mount"
                 brick_path = mount_path + "/" + details["brick_name"]
                 brick_dict[host].update({
-                    dev_name: {
+                    dev: {
                         "node_id": k,
                         "mount_path": mount_path,
                         "brick_path": brick_path,
-                        "lv": "tendrl" + brick_path.replace("/", "_") + "_lv",
-                        "pv": "tendrl" + brick_path.replace("/", "_") + "_pv",
-                        "pool": "tendrl" + brick_path.replace("/", "_") + "_pool",
-                        "vg": "tendrl" + brick_path.replace("/", "_") + "_vg",
+                        "lv": "tendrl" + details["brick_name"] + "_lv",
+                        "pv": "tendrl" + details["brick_name"] + "_pv",
+                        "pool": "tendrl" + details["brick_name"] + "_pool",
+                        "vg": "tendrl" + details["brick_name"] + "_vg",
                     }
                 })
         
@@ -87,8 +88,13 @@ class Create(objects.BaseAtom):
                         pool=val["pool"],
                         pv=val["pv"],
                         **args
-                    ).save(update=False)
-
+                    ).save()
+                    free_brick_key = "clusters/%s/nodes/%s/GlusterBricks/free/%s" % (
+                        NS.tendrl_context.integration_id,
+                        val["node_id"],
+                        brick_name.replace("/","_")
+                    )
+                    NS._int.wclient.write(free_brick_key, "")
             return True
         else:
             Event(

--- a/tendrl/gluster_integration/objects/gluster_brick_path/__init__.py
+++ b/tendrl/gluster_integration/objects/gluster_brick_path/__init__.py
@@ -1,0 +1,23 @@
+from tendrl.commons import objects
+
+
+class GlusterBrickDir(objects.BaseObject):
+    def __init__(
+        self,
+        default_brick_dir=None,
+        *args,
+        **kwargs
+    ):
+        super(GlusterBrickDir, self).__init__(*args, **kwargs)
+
+        self.default_brick_dir = default_brick_dir if default_brick_dir else \
+                                  NS.config.data.get(
+                                      'gluster_bricks_dir', "/tendrl_gluster_bricks"
+                                  )
+        self.value = 'clusters/{0}/GlusterBrickDir'
+
+    def render(self):
+        self.value = self.value.format(
+            NS.tendrl_context.integration_id,
+        )
+        return super(GlusterBrickDir, self).render()

--- a/tendrl/gluster_integration/sds_sync/__init__.py
+++ b/tendrl/gluster_integration/sds_sync/__init__.py
@@ -29,6 +29,10 @@ class GlusterIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
             )
         )
 
+        gluster_brick_dir = NS.gluster.objects.\
+                            GlusterBrickDir()
+        gluster_brick_dir.save()
+
         while not self._complete.is_set():
             try:
                 # Acquire lock before updating the volume details in etcd


### PR DESCRIPTION
This patch classifies the gluster bricks as used and
free based on if its used in a gluster volume. Also
this patch adds a cluster level object to hold the
default gluster brick path

tendrl-bug-id: https://github.com/Tendrl/gluster-integration/issues/252
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>