### PR TITLE
Update brick device details as part of sync.

### DIFF
--- a/tendrl-gluster-integration.spec
+++ b/tendrl-gluster-integration.spec
@@ -15,6 +15,7 @@ BuildRequires: python-mock
 Requires: tendrl-commons
 Requires: systemd
 Requires: gstatus
+Requires: python-blivet
 
 %description
 Python module for Tendrl gluster bridge to manage gluster tasks.

--- a/tendrl/gluster_integration/objects/brick/__init__.py
+++ b/tendrl/gluster_integration/objects/brick/__init__.py
@@ -5,7 +5,7 @@ class Brick(objects.BaseObject):
     def __init__(
         self,
         name,
-        disk=None,
+        devices=None,
         brick_path=None,
         mount_path=None,
         node_id=None,
@@ -31,7 +31,7 @@ class Brick(objects.BaseObject):
     ):
         super(Brick, self).__init__(*args, **kwargs)
 
-        self.disk = disk
+        self.devices = devices
         self.name = name
         self.node_id = node_id
         self.brick_path = brick_path

--- a/tendrl/gluster_integration/sds_sync/brick_device_details.py
+++ b/tendrl/gluster_integration/sds_sync/brick_device_details.py
@@ -1,0 +1,67 @@
+from tendrl.commons.utils import cmd_utils
+from tendrl.commons.utils import log_utils as logger
+
+
+def get_brick_source_and_mount(brick_path):
+    # source and target correspond to fields "Filesystem" and
+    # "Mounted on" from df command output. The below command
+    # gives the filesystem and mount point for a given path,
+    # Eg: "/dev/mapper/tendrlMyBrick4_vg-tendrlMyBrick4_lv " \
+    #     "/tendrl_gluster_bricks/MyBrick4_mount"
+
+    command = "df --output=source,target " + brick_path.split(":")[-1]
+    cmd = cmd_utils.Command(command)
+    out, err, rc = cmd.run()
+    if rc != 0:
+        logger.log(
+            "error",
+            NS.publisher_id,
+            {
+                "message": "%s command failed: %s" % (
+                    command, err
+                )
+            }
+        )
+        return None, None
+    return out.split("\n")[-1].split()
+
+
+def update_brick_device_details(brick_name, brick_path, devicetree):
+    mount_source, mount_point = get_brick_source_and_mount(brick_path)
+    if not mount_source or not mount_point:
+        logger.log(
+            "error",
+            NS.publisher_id,
+            {
+                "message": "Cound not update brick device details"
+            }
+        )
+        return
+
+    device = devicetree.resolveDevice(mount_source)
+    size = int(device.size.to_integral())
+    lv = None
+    pool = None
+    vg = None
+    pvs = None
+    disks = [d.path for d in device.ancestors if d.isDisk and not d.parents]
+
+    if device.type in ("lvmthinlv", "lvmlv"):
+        lv = device.name
+        if hasattr(device, "pool"):
+            pool = device.pool.name
+        vg = device.vg.name
+        pvs = [dev.path for dev in device.disks]
+
+    brick = NS.gluster.objects.Brick(
+        brick_name,
+        devices=disks,
+        mount_path=mount_point,
+        lv=lv,
+        vg=vg,
+        pool=pool,
+        pv=pvs,
+        size=size
+    )
+
+    brick.save()


### PR DESCRIPTION
This patch gathers the gluster brick device details and
updates it during the sds sync. It uses blivet to gather
the node's storage device details.

Using the brick path the brick mount-point and filesystem
is gathered first. using these details we search for the
brick device in blivet's devicetree. Blivet's device tree
will have the details about the underlying device.

tendrl-bug-id: Tendrl/gluster-integration#333
tendrl-bug-id: Tendrl/specifications#173
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>