### PR TITLE
Packaging: snapshot srpm version with timestamp and shortcommit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,6 @@ VERSION := $(shell PYTHONPATH=. python -c \
 RELEASE=1
 COMMIT := $(shell git rev-parse HEAD)
 SHORTCOMMIT := $(shell echo $(COMMIT) | cut -c1-7)
-GIT_RELEASE := $(shell git describe --tags --match 'v*' \
-                 | sed 's/^v//' \
-                 | sed 's/^[^-]*-//' \
-                 | sed 's/-.*//')
 
 all: srpm
 
@@ -25,18 +21,12 @@ srpm: dist
 	fedpkg --dist epel7 srpm
 
 rpm: dist
-	mock -r epel-7-x86_64 rebuild $(NAME)-$(VERSION)-$(RELEASE).el7.src.rpm --resultdir=. --define "dist .el7"
+	mock -r epel-7-x86_64 rebuild $(NAME)-$(VERSION)-*.src.rpm --resultdir=. --define "dist .el7"
 
 gitversion:
 	# Set version and release to the latest values from Git
-	$(eval VERSION := $(VERSION).dev$(GIT_RELEASE))
-	$(eval RELEASE := $(GIT_RELEASE).$(SHORTCOMMIT))
-	sed -i version.py \
-	  -e "s/^__version__ = .*/__version__ = '$(VERSION)'/"
-	sed -i tendrl-gluster-integration.spec \
-	  -e "s/^Version: .*/Version: $(VERSION)/"
-	sed -i tendrl-gluster-integration.spec \
-	  -e "s/^Release: .*/Release: $(RELEASE)/"
+	sed -i $(NAME).spec \
+	  -e "/^Release:/cRelease: $(shell date +"%Y%m%dT%H%M%S").$(SHORTCOMMIT)"
 
 snapshot: gitversion srpm
 

--- a/tendrl-gluster-integration.spec
+++ b/tendrl-gluster-integration.spec
@@ -1,6 +1,6 @@
 Name: tendrl-gluster-integration
 Version: 1.4.2
-Release: 1%{?dist}
+Release: 20170802T141735.d80b2d7
 BuildArch: noarch
 Summary: Module for Gluster Integration
 Source0: %{name}-%{version}.tar.gz

--- a/tendrl-gluster-integration.spec
+++ b/tendrl-gluster-integration.spec
@@ -1,6 +1,6 @@
 Name: tendrl-gluster-integration
 Version: 1.4.2
-Release: 20170802T141735.d80b2d7
+Release: 1%{?dist}
 BuildArch: noarch
 Summary: Module for Gluster Integration
 Source0: %{name}-%{version}.tar.gz


### PR DESCRIPTION
Update makefile for snapshot srpm version to have timestamp
and shortcommit

tendrl-bug-id: Tendrl/gluster-integration#348
Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>