### PR TITLE
Added logic to enable / disable volume profiling

### DIFF
--- a/tendrl/gluster_integration/objects/definition/gluster.yaml
+++ b/tendrl/gluster_integration/objects/definition/gluster.yaml
@@ -728,6 +728,9 @@ namespace.gluster:
         quorum_status:
           help: "Quorum status"
           type: String
+        profiling_enabled:
+          help: Whether profiling is enabled
+          type: Boolean
       enabled: true
       value: clusters/$TendrlContext.integration_id/Volumes/$Volume.vol_id/
       list: clusters/$TendrlContext.integration_id/Volumes

--- a/tendrl/gluster_integration/objects/volume/__init__.py
+++ b/tendrl/gluster_integration/objects/volume/__init__.py
@@ -25,6 +25,7 @@ class Volume(objects.BaseObject):
         usable_capacity=None,
         used_capacity=None,
         pcnt_used=None,
+        profiling_enabled=False,
         *args,
         **kwargs
     ):
@@ -51,6 +52,7 @@ class Volume(objects.BaseObject):
         self.usable_capacity = usable_capacity
         self.used_capacity = used_capacity
         self.pcnt_used = pcnt_used
+        self.profiling_enabled = profiling_enabled
         self.value = 'clusters/{0}/Volumes/{1}'
 
     def render(self):

--- a/tendrl/gluster_integration/sds_sync/__init__.py
+++ b/tendrl/gluster_integration/sds_sync/__init__.py
@@ -650,7 +650,9 @@ class GlusterIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
                     _cluster.save()
 
                 # check and enable volume profiling
-                self._enable_disable_volume_profiling()
+                if "provisioner/%s" % NS.tendrl_context.integration_id in \
+                    NS.node_context.tags:
+                    self._enable_disable_volume_profiling()
 
             except Exception as ex:
                 Event(

--- a/tendrl/gluster_integration/sds_sync/__init__.py
+++ b/tendrl/gluster_integration/sds_sync/__init__.py
@@ -649,6 +649,9 @@ class GlusterIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
                     _cluster.is_managed = "yes"
                     _cluster.save()
 
+                # check and enable volume profiling
+                self._enable_disable_volume_profiling()
+
             except Exception as ex:
                 Event(
                     ExceptionMessage(
@@ -668,3 +671,43 @@ class GlusterIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
                 payload={"message": "%s complete" % self.__class__.__name__}
             )
         )
+
+    def _enable_disable_volume_profiling(self):
+        cluster = NS.tendrl.objects.Cluster(
+            integration_id=NS.tendrl_context.integration_id
+        )
+        volumes = NS.gluster.objects.Volume().load_all()
+        failed_vols = []
+        for volume in volumes:
+            if cluster.enable_volume_profiling:
+                if volume.profiling_enabled == 'False':
+                    action = "start"
+                else:
+                    continue
+            else:
+                if volume.profiling_enabled == 'True':
+                    action = "stop"
+                else:
+                    continue
+            out, err, rc = cmd_utils.Command(
+                "gluster volume profile %s %s" %
+                (volume.name,
+                action)
+            ).run()
+            if err or rc != 0:
+                failed_vols.append(volume.name)
+                continue
+            volume.profiling_enabled = cluster.enable_volume_profiling
+            volume.save()
+        if len(failed_vols) > 0:
+            Event(
+                Message(
+                    priority="warning",
+                    publisher=NS.publisher_id,
+                    payload={
+                        "message": "%sing profiling failed for volumes: %s" %
+                        (action,
+                        str(failed_vols))
+                    }
+                )
+            )


### PR DESCRIPTION
If cluster level flag is set to enable profiling, while syncing
the cluster volumes, profiling would be enabled for all the
volumes, else disabled.

tendrl-bug-id: Tendrl/gluster-integration#353
Signed-off-by: Shubhendu <shtripat@redhat.com>