### PR TITLE
Add geo replication session details in etcd

### DIFF
--- a/tendrl/gluster_integration/objects/definition/gluster.yaml
+++ b/tendrl/gluster_integration/objects/definition/gluster.yaml
@@ -180,6 +180,87 @@ namespace.gluster:
       value: clusters/$TendrlContext.integration_id/Volumes/$Volume.vol_id/RebalanceDetails/$TendrlContext.node_id
       list: clusters/$TendrlContext.integration_id/Volumes/$Volume.vol_id/RebalanceDetails
       help: gluster volume rebalance details
+    GeoReplicationPair:
+      attrs:
+        vol_id:
+          help: Volume id
+          type: String
+        session_id:
+          help: "unique id of geo replication session"
+          type: String
+        pair:
+          help: "geo replication session pair name"
+          type: String
+        master_node:
+          help: "master node ip/fqdn"
+          typoe: String
+        master_volume:
+          help: "master volume name"
+          type: String
+        master_brick:
+          help: "master brick name"
+          type: String
+        slave_user:
+          help: "slave user name"
+          type: String
+        slave:
+          help: "slave host and volume name"
+          type: String
+        slave_node:
+          help: "slave node with which geo-rep session is going"
+          type: String
+        status:
+          help: "geo replication session status"
+          type: String
+        crawl_status:
+          help: "geo replication crawl status"
+          typoe: String
+        last_synced:
+          help: "last synced time"
+          type: String
+        entry:
+          help: "entries synced"
+          type: String
+        data:
+          help: "data synced"
+          type: String
+        meta:
+          help: "metadata synced"
+          type: String
+        failures:
+          help: "number of failures"
+          type: String
+        checkpoint_time:
+          help: "checkpoint time"
+          type: String
+        checkpoint_completed:
+          help: "if checkpoint is completed"
+          type: String
+        checkpoint_completion_time:
+          help: "time of checkpoint completion"
+          type: String
+      enabled: true
+      value: clusters/$TendrlContext.integration_id/Volumes/$Volume.vol_id/GeoReplicationSessions/$GeoReplicationPair.session_id/pairs/$GeoReplicationPair.pair
+      list: clusters/$TendrlContext.integration_id/Volumes/$Volume.vol_id/GeoReplicationSessions/$GeoReplicationPair.session_id/pairs
+      help: gluster volume geo replication pair details
+    GeoReplicationSession:
+      attrs:
+        vol_id:
+          help: Volume id
+          type: String
+        session_id:
+          help: "unique id of geo replication session"
+          type: String
+        pairs:
+          help: "geo replication session pair list"
+          type: List
+        session_status:
+          help: "aggregated status of geo-replication session"
+          typoe: String
+      enabled: true
+      value: clusters/$TendrlContext.integration_id/Volumes/$Volume.vol_id/GeoReplicationSessions/$GeoReplicationPair.session_id
+      list: clusters/$TendrlContext.integration_id/Volumes/$Volume.vol_id/GeoReplicationSessions
+      help: gluster volume geo replication session details
     Brick:
       atoms:
         Create:

--- a/tendrl/gluster_integration/objects/definition/gluster.yaml
+++ b/tendrl/gluster_integration/objects/definition/gluster.yaml
@@ -163,7 +163,7 @@ namespace.gluster:
           type: Integer
         rebal_id:
           help: "UUID of the rabalance task"
-          typoe: String
+          type: String
         rebal_lookedup:
           help: "Looked up files for rebalance"
           type: Integer
@@ -193,7 +193,7 @@ namespace.gluster:
           type: String
         master_node:
           help: "master node ip/fqdn"
-          typoe: String
+          type: String
         master_volume:
           help: "master volume name"
           type: String

--- a/tendrl/gluster_integration/objects/definition/gluster.yaml
+++ b/tendrl/gluster_integration/objects/definition/gluster.yaml
@@ -214,7 +214,7 @@ namespace.gluster:
           type: String
         crawl_status:
           help: "geo replication crawl status"
-          typoe: String
+          type: String
         last_synced:
           help: "last synced time"
           type: String
@@ -256,7 +256,7 @@ namespace.gluster:
           type: List
         session_status:
           help: "aggregated status of geo-replication session"
-          typoe: String
+          type: String
       enabled: true
       value: clusters/$TendrlContext.integration_id/Volumes/$Volume.vol_id/GeoReplicationSessions/$GeoReplicationPair.session_id
       list: clusters/$TendrlContext.integration_id/Volumes/$Volume.vol_id/GeoReplicationSessions

--- a/tendrl/gluster_integration/objects/geo_replication_pair/__init__.py
+++ b/tendrl/gluster_integration/objects/geo_replication_pair/__init__.py
@@ -1,0 +1,59 @@
+from tendrl.commons import objects
+
+
+class GeoReplicationPair(objects.BaseObject):
+    def __init__(
+        self,
+        vol_id,
+        session_id,
+        pair,
+        master_node=None,
+        master_volume=None,
+        master_brick=None,
+        slave_user=None,
+        slave=None,
+        slave_node=None,
+        status=None,
+        crawl_status=None,
+        last_synced=None,
+        entry=None,
+        data=None,
+        meta=None,
+        failures=None,
+        checkpoint_time=None,
+        checkpoint_completed=None,
+        checkpoint_completion_time=None,
+        *args,
+        **kwargs
+    ):
+        super(GeoReplicationPair, self).__init__(*args, **kwargs)
+
+        self.vol_id = vol_id
+        self.session_id = session_id
+        self.pair = pair
+        self.master_node = master_node
+        self.master_volume = master_node
+        self.master_brick = master_brick
+        self.slave_user = slave_user
+        self.slave = slave
+        self.slave_node = slave_node
+        self.status = status
+        self.crawl_status = crawl_status
+        self.last_synced = last_synced
+        self.entry = entry
+        self.data = data
+        self.meta = meta
+        self.failures = failures
+        self.checkpoint_time = checkpoint_time
+        self.checkpoint_completed = checkpoint_completed
+        self.checkpoint_completion_time = checkpoint_completion_time
+        self.value = 'clusters/{0}/Volumes/{1}/GeoRepSessions/{2}/pairs/{3}'
+
+    def render(self):
+        self.value = self.value.format(
+            NS.tendrl_context.integration_id,
+            self.vol_id,
+            self.session_id,
+            self.pair
+        )
+        return super(GeoReplicationPair, self).render()

--- a/tendrl/gluster_integration/objects/geo_replication_session/__init__.py
+++ b/tendrl/gluster_integration/objects/geo_replication_session/__init__.py
@@ -1,0 +1,35 @@
+from tendrl.commons import objects
+
+
+class GeoReplicationSessionStatus(object):
+    ACTIVE = "active"
+    PARTIAL = "partial"
+    FAULTY = "faulty"
+
+
+class GeoReplicationSession(objects.BaseObject):
+    def __init__(
+        self,
+        vol_id,
+        session_id,
+        session_status,
+        pairs=None,
+        *args,
+        **kwargs
+    ):
+        super(GeoReplicationSession, self).__init__(*args, **kwargs)
+
+        self.vol_id = vol_id
+        self.session_id = session_id
+        self.session_status = session_status
+        if pairs:
+            self.pairs = pairs
+        self.value = 'clusters/{0}/Volumes/{1}/GeoRepSessions/{2}'
+
+    def render(self):
+        self.value = self.value.format(
+            NS.tendrl_context.integration_id,
+            self.vol_id,
+            self.session_id
+        )
+        return super(GeoReplicationSession, self).render()

--- a/tendrl/gluster_integration/sds_sync/__init__.py
+++ b/tendrl/gluster_integration/sds_sync/__init__.py
@@ -497,7 +497,8 @@ class GlusterIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
                         vol_options.save()
 
                 # aggregate geo-replication status
-                georep_details.aggregate_session_status()
+                if "provisioner/gluster" in NS.node_context.tags:
+                    georep_details.aggregate_session_status()
 
                 # Sync the cluster status details
                 args = ["gstatus", "-o", "json"]

--- a/tendrl/gluster_integration/sds_sync/__init__.py
+++ b/tendrl/gluster_integration/sds_sync/__init__.py
@@ -15,6 +15,7 @@ from tendrl.commons.utils import etcd_utils
 from tendrl.commons.utils.time_utils import now as tendrl_now
 from tendrl.gluster_integration import ini2json
 from tendrl.gluster_integration.sds_sync import brick_utilization
+from tendrl.gluster_integration.sds_sync import georep_details
 from tendrl.gluster_integration.sds_sync import rebalance_status as rebal_stat
 
 
@@ -290,6 +291,7 @@ class GlusterIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
                                 ],
                             )
                             rebal_det.save(ttl=SYNC_TTL)
+                            georep_details.save_georep_details(volumes, index)
                             b_index = 1
                             # ipv4 address of current node
                             try:
@@ -493,6 +495,9 @@ class GlusterIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
                                 options=dict1
                             )
                         vol_options.save()
+
+                # aggregate geo-replication status
+                georep_details.aggregate_session_status()
 
                 # Sync the cluster status details
                 args = ["gstatus", "-o", "json"]

--- a/tendrl/gluster_integration/sds_sync/georep_details.py
+++ b/tendrl/gluster_integration/sds_sync/georep_details.py
@@ -1,0 +1,157 @@
+import etcd
+from tendrl.gluster_integration.objects.geo_replication_pair\
+    import GeoReplicationPair
+from tendrl.gluster_integration.objects.geo_replication_session\
+    import GeoReplicationSession
+from tendrl.gluster_integration.objects.geo_replication_session\
+    import GeoReplicationSessionStatus
+
+
+def save_georep_details(volumes, index):
+    pair_index = 1
+    while True:
+        try:
+            session_id = "{0}_{1}_{2}".format(
+                volumes[
+                    'volume%s.pair%s.master_volume' % (
+                        index, pair_index
+                    )
+                ],
+                volumes[
+                    'volume%s.pair%s.slave' % (
+                        index, pair_index)
+                ].split("::")[-1],
+                volumes[
+                    'volume%s.pair%s.session_slave' % (
+                        index, pair_index)
+                ].split(":")[-1]
+            )
+            pair_name = "{0}-{1}".format(
+                volumes[
+                    'volume%s.pair%s.master_node' % (
+                        index, pair_index)
+                ],
+                volumes[
+                    'volume%s.pair%s.master_brick' % (
+                        index, pair_index)
+                ].replace("/", "_")
+            )
+            pair = NS.gluster.objects.GeoReplicationPair(
+                vol_id=volumes['volume%s.id' % index],
+                session_id=session_id,
+                pair=pair_name,
+                master_volume=volumes[
+                    'volume%s.pair%s.master_volume' % (
+                        index, pair_index)],
+                master_brick=volumes[
+                    'volume%s.pair%s.master_brick' % (
+                        index, pair_index)],
+                master_node=volumes[
+                    'volume%s.pair%s.master_node' % (
+                        index, pair_index)],
+                slave_user=volumes[
+                    'volume%s.pair%s.slave_user' % (
+                        index, pair_index)],
+                slave=volumes[
+                    'volume%s.pair%s.slave' % (
+                        index, pair_index)],
+                slave_node=volumes[
+                    'volume%s.pair%s.slave_node' % (
+                        index, pair_index)],
+                status=volumes[
+                    'volume%s.pair%s.status' % (
+                        index, pair_index)],
+                crawl_status=volumes[
+                    'volume%s.pair%s.crawl_status' % (
+                        index, pair_index)],
+                last_synced=volumes[
+                    'volume%s.pair%s.last_synced' % (
+                        index, pair_index)],
+                entry=volumes[
+                    'volume%s.pair%s.entry' % (
+                        index, pair_index)],
+                data=volumes[
+                    'volume%s.pair%s.data' % (
+                        index, pair_index)],
+                meta=volumes[
+                    'volume%s.pair%s.meta' % (
+                        index, pair_index)],
+                failures=volumes[
+                    'volume%s.pair%s.failures' % (
+                        index, pair_index)],
+                checkpoint_time=volumes[
+                    'volume%s.pair%s.checkpoint_time' % (
+                        index, pair_index)],
+                checkpoint_completed=volumes[
+                    'volume%s.pair%s.checkpoint_completed' % (
+                        index, pair_index)],
+                checkpoint_completed_time=volumes[
+                    'volume%s.pair%s.checkpoint_completion_time' % (
+                        index, pair_index)]
+            )
+        except KeyError:
+            break
+        pair.save()
+        pair_index += 1
+    return
+
+
+def aggregate_session_status():
+    volumes = None
+    try:
+        volumes = NS._int.client.read(
+            "clusters/%s/Volumes" % NS.tendrl_context.integration_id
+        )
+    except etcd.EtcdKeyNotFound:
+        # ignore as no volumes available till now
+        return
+    georep_status = GeoReplicationSessionStatus()
+    if volumes:
+        for entry in volumes.leaves:
+            vol_id = entry.key.split("Volumes/")[-1]
+            try:
+                sessions = NS._int.client.read(
+                    "clusters/%s/Volumes/%s/GeoRepSessions" % (
+                        NS.tendrl_context.integration_id,
+                        vol_id,
+                    )
+                )
+            except etcd.EtcdKeyNotFound:
+                continue
+            for session in sessions.leaves:
+                session_status = None
+                session_id = session.key.split("GeoRepSessions/")[-1]
+                try:
+                    pairs = NS._int.client.read(
+                        "clusters/%s/Volumes/%s/GeoRepSessions"
+                        "/%s/pairs" % (
+                            NS.tendrl_context.integration_id,
+                            vol_id,
+                            session_id
+                        )
+                    )
+                except etcd.EtcdKeyNotFound:
+                    continue
+                pair_count = 0
+                faulty_count = 0
+                for element in pairs.leaves:
+                    pair = GeoReplicationPair(
+                        vol_id=vol_id,
+                        session_id=session_id,
+                        pair=element.key.split("pairs/")[-1]
+                    ).load()
+                    if pair.status == "Faulty":
+                        faulty_count += 1
+                    pair_count += 1
+                if pair_count == faulty_count:
+                    session_status = georep_status.FAULTY
+                elif faulty_count == 0:
+                    session_status = georep_status.ACTIVE
+                else:
+                    session_status = georep_status.PARTIAL
+                geo_replication_session = GeoReplicationSession(
+                    vol_id=vol_id,
+                    session_id=session_id,
+                    session_status=session_status
+                )
+                geo_replication_session.save()


### PR DESCRIPTION
This patch adds methods and objects for syncing gluster
geo replication session related details under volume in
etcd.

tendrl-bug-id: Tendrl/specifications#167
tendrl-bug-id: Tendrl/gluster-integration#340
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>