### PR TITLE
Find rebalance status for all distribute volumes

### DIFF
--- a/tendrl/gluster_integration/sds_sync/rebalance_status.py
+++ b/tendrl/gluster_integration/sds_sync/rebalance_status.py
@@ -50,7 +50,7 @@ def sync_volume_rebalance_estimated_time(volumes):
 
 def sync_volume_rebalance_status(volumes):
     for volume in volumes:
-        if volume.vol_type.startswith("Distribute"):
+        if "Distribute" in volume.vol_type:
             status = get_rebalance_status(
                 volume.name
             )

--- a/tendrl/gluster_integration/sds_sync/rebalance_status.py
+++ b/tendrl/gluster_integration/sds_sync/rebalance_status.py
@@ -50,7 +50,7 @@ def sync_volume_rebalance_estimated_time(volumes):
 
 def sync_volume_rebalance_status(volumes):
     for volume in volumes:
-        if volume.vol_type == "Distribute":
+        if volume.vol_type.startswith("Distribute"):
             status = get_rebalance_status(
                 volume.name
             )


### PR DESCRIPTION
Earlier rebalance status was calculated for only pure distribute volume. Now it has been edited to gather status for all types of distribute volume