### PR TITLE
Added retry option for `gluster v status` command

### DIFF
--- a/tendrl/gluster_integration/sds_sync/rebalance_status.py
+++ b/tendrl/gluster_integration/sds_sync/rebalance_status.py
@@ -13,8 +13,9 @@ def get_rebalance_status(volume):
 
     index = 0
     while True:
+        gevent.sleep(RETRY_INTERVAL)
         index += 1
-        if index == RETRY_COUNT:
+        if index >= RETRY_COUNT:
             Event(
                 Message(
                     priority="error",
@@ -30,7 +31,6 @@ def get_rebalance_status(volume):
         out, err, rc = cmd.run()
         if rc == 0:
             break
-        gevent.sleep(RETRY_INTERVAL)
 
     tree = etree.fromstring(out)
     rv = int(tree.find('opRet').text)

--- a/tendrl/gluster_integration/sds_sync/rebalance_status.py
+++ b/tendrl/gluster_integration/sds_sync/rebalance_status.py
@@ -1,20 +1,36 @@
+import gevent
+
 from tendrl.commons.event import Event
 from tendrl.commons.message import Message
 from tendrl.commons.utils import cmd_utils
 import xml.etree.cElementTree as etree
 
+RETRY_COUNT = 3
+RETRY_INTERVAL = 2
 
 def get_rebalance_status(volume):
     cmd = cmd_utils.Command('gluster volume status %s --xml' % volume)
-    out, err, rc = cmd.run()
-    if rc != 0:
-        Event(
-            Message(
-                priority="error",
-                publisher=NS.publisher_id,
-                payload={"message": "volume status command failed: %s" % err}
+
+    index = 0
+    while True:
+        index += 1
+        if index == RETRY_COUNT:
+            Event(
+                Message(
+                    priority="error",
+                    publisher=NS.publisher_id,
+                    payload={
+                        "message": "volume status command"
+                        " failed after retries: %s" % err
+                    }
+                )
             )
-        )
+            return None
+
+        out, err, rc = cmd.run()
+        if rc == 0:
+            break
+        gevent.sleep(RETRY_INTERVAL)
 
     tree = etree.fromstring(out)
     rv = int(tree.find('opRet').text)


### PR DESCRIPTION
This is to make sure even if command fails due to transient
collisions, we retry at least no of times.

tendrl-bug-id: Tendrl/gluster-integration#374
Signed-off-by: Shubhendu <shtripat@redhat.com>