### PR TITLE
Enable gluster native events in tendrl.

### DIFF
--- a/tendrl-gluster-integration.spec
+++ b/tendrl-gluster-integration.spec
@@ -12,9 +12,11 @@ BuildRequires: python2-devel
 BuildRequires: pytest
 BuildRequires: python-mock
 
+Requires: glusterfs-events
 Requires: tendrl-commons
 Requires: systemd
 Requires: python-blivet
+Requires: python-flask
 
 %description
 Python module for Tendrl gluster bridge to manage gluster tasks.

--- a/tendrl/gluster_integration/manager/__init__.py
+++ b/tendrl/gluster_integration/manager/__init__.py
@@ -9,6 +9,8 @@ from tendrl.commons import TendrlNS
 from tendrl import gluster_integration
 from tendrl.gluster_integration.gdeploy_wrapper.manager import \
     ProvisioningManager
+from tendrl.gluster_integration.message.gluster_native_message_handler\
+    import GlusterNativeMessageHandler
 from tendrl.gluster_integration import sds_sync
 
 
@@ -19,7 +21,8 @@ class GlusterIntegrationManager(common_manager.Manager):
             GlusterIntegrationManager,
             self
         ).__init__(
-            NS.state_sync_thread
+            NS.state_sync_thread,
+            message_handler_thread=NS.message_handler_thread
         )
 
 
@@ -31,6 +34,8 @@ def main():
     NS.publisher_id = "gluster_integration"
 
     NS.state_sync_thread = sds_sync.GlusterIntegrationSdsSyncStateThread()
+
+    NS.message_handler_thread = GlusterNativeMessageHandler()
 
     NS.node_context.save()
     try:

--- a/tendrl/gluster_integration/message/callback.py
+++ b/tendrl/gluster_integration/message/callback.py
@@ -1,0 +1,22 @@
+# The callback function names below should match(in small case)
+# the event_type field of gluster native events as documented
+# at: https://gluster.readthedocs.io/en/latest/Administrator%20Guide/
+# Events%20APIs/ .
+# Whenever gluster-integration receives a gluster native event,
+# event handler checks if there is a callback function defined for
+# that event in this file, If it finds then that callback function
+# will be invoked
+
+
+class Callback(object):
+    def peer_connect(self, event):
+        pass
+
+    def peer_disconnect(self, event):
+        pass
+
+    def volume_create(self, event):
+        pass
+
+    def volume_delete(self, event):
+        pass

--- a/tendrl/gluster_integration/message/gluster_native_message_handler.py
+++ b/tendrl/gluster_integration/message/gluster_native_message_handler.py
@@ -1,0 +1,101 @@
+from flask import Flask
+from flask import request
+import gevent
+import gevent.event
+import gevent.greenlet
+from gevent.wsgi import WSGIServer
+
+from tendrl.commons.utils import cmd_utils
+from tendrl.commons.utils import log_utils as logger
+from tendrl.commons.utils import service as svc
+from tendrl.commons.utils import service_status as svc_stat
+from tendrl.gluster_integration.message import callback as cb
+
+
+app = Flask(__name__)
+
+
+class GlusterNativeMessageHandler(gevent.greenlet.Greenlet):
+    def __init__(self):
+        super(GlusterNativeMessageHandler, self).__init__()
+        self.path = "/listen"
+        self.host = "0.0.0.0"
+        self.port = 8697
+        self.callback = cb.Callback()
+
+        @app.route(self.path, methods=["POST"])
+        def events_listener():
+            gluster_event = request.json
+            if gluster_event:
+                callback_function_name = gluster_event["event"].lower()
+                try:
+                    function = getattr(self.callback, callback_function_name)
+                except AttributeError:
+                    # tendrl does not handle this perticular event hence ignore
+                    pass
+                event_handler = gevent.spawn(function, gluster_event)
+                event_handler.join()
+
+    def _setup_gluster_native_message_reciever(self):
+        service = svc.Service("glustereventsd")
+        message, success = service.start()
+        gluster_eventsd = svc_stat.ServiceStatus("glustereventsd")
+        if not gluster_eventsd.status():
+            if not success:
+                logger.log(
+                    "error",
+                    NS.publisher_id,
+                    {
+                        "message": "glustereventsd could"
+                        " not be started: %s" % message
+                    }
+                )
+                return False
+
+        url = "http://{0}:{1}{2}".format(self.host, str(self.port), self.path)
+        cmd = cmd_utils.Command('gluster-eventsapi webhook-add %s' % url)
+        out, err, rc = cmd.run()
+        if rc != 0:
+            logger.log(
+                "error",
+                NS.publisher_id,
+                {
+                    "message": "could not add webhook"
+                    " for glustereventsd. Error: %s" % err
+                }
+            )
+        return True
+
+    def _cleanup_gluster_native_message_reciever(self):
+        url = "http://{0}:{1}{2}".format(self.host, str(self.port), self.path)
+        cmd = cmd_utils.Command('gluster-eventsapi webhook-del %s' % url)
+        out, err, rc = cmd.run()
+        if rc != 0:
+            logger.log(
+                "error",
+                NS.publisher_id,
+                {
+                    "message": "could not delete webhook from"
+                    " glustereventsd. Error: %s" % err
+                }
+            )
+        return True
+
+    def stop(self):
+        if not self._cleanup_gluster_native_message_reciever():
+            logger.log(
+                "error",
+                NS.publisher_id,
+                {"message": "gluster native message reciever cleanup failed"}
+            )
+
+    def _run(self):
+        if not self._setup_gluster_native_message_reciever():
+            logger.log(
+                "error",
+                NS.publisher_id,
+                {"message": "gluster native message reciever setup failed"}
+            )
+            return
+        event_receiver = WSGIServer((self.host, self.port), app)
+        event_receiver.serve_forever()


### PR DESCRIPTION
This patch adds a mechanism in gluster integration to
receive gluster native events that are pushed by
glustereventsd. It also takes care of setup and cleanup
of webhooks needed for recieving events. This patch also
adds place holders for few sample event handler functions

tendrl-bug-id: Tendrl/specifications#180
tendrl-bug-id: Tendrl/gluster-integration#361
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>