### PR TITLE
Change the path where brick details are saved.

### DIFF
--- a/tendrl/gluster_integration/objects/brick/__init__.py
+++ b/tendrl/gluster_integration/objects/brick/__init__.py
@@ -57,11 +57,12 @@ class Brick(objects.BaseObject):
         self.used = used
         self.client_count = client_count
         self.is_arbiter = is_arbiter
-        self.value = 'clusters/{0}/Bricks/all/{1}'
+        self.value = 'clusters/{0}/Bricks/all/{1}/{2}'
 
     def render(self):
         self.value = self.value.format(
             NS.tendrl_context.integration_id,
-            self.name.replace("/", "_").replace(" ", "")
+            self.name.split(":")[0],
+            self.name.replace("/", "_").replace(" ", "").split(":_")[-1]
         )
         return super(Brick, self).render()


### PR DESCRIPTION
Currently the brick details are saved at:
clusters/<cluster-id>/bricks/all/<host:brick-dir-path>
This PR changes the path to:
clusters/<cluster-id>/bricks/all/<host>/<brick-dir-path>.

The reason for this change is API can easily get a list
of all bricks under a host with the new structure.

tendrl-bug-id: Tendrl/gluster-integration#388
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>