### PR TITLE
Added volume name as well in resource while brick add/delete

### DIFF
--- a/tendrl/gluster_integration/message/callback.py
+++ b/tendrl/gluster_integration/message/callback.py
@@ -431,7 +431,7 @@ class Callback(object):
         added_bricks = event['message']['bricks'].split(" ")
         for brick in added_bricks:
             job_id = monitoring_utils.update_dashboard(
-                brick,
+                "%s|%s" % (event['message']['volume'], brick),
                 RESOURCE_TYPE_BRICK,
                 NS.tendrl_context.integration_id,
                 "add"
@@ -450,7 +450,7 @@ class Callback(object):
         bricks = event['message']['bricks'].split(" ")
         for brick in bricks:
             job_id = monitoring_utils.update_dashboard(
-                brick,
+                "%s|%s" % (event['message']['volume'], brick),
                 RESOURCE_TYPE_BRICK,
                 NS.tendrl_context.integration_id,
                 "delete"


### PR DESCRIPTION
While invoking update dashboard flow for brick add/delete, the
monitoring-integration needs volume name as well. Added the volume
name as part resource_name parameter of the flow in the form
`{vol_name}|{brick-host-name}:{brick-path}`

tendrl-bug-id: Tendrl/gluster-integration#413
Signed-off-by: Shubhendu <shtripat@redhat.com>