### PR TITLE
Packaging: Fix build failure due to missing bzip-selinux-policy target

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include AUTHORS
 include ChangeLog
 include tendrl-gluster-integration.service
 include version.py
+include Makefile
 exclude .gitignore
 exclude .gitreview
 graft docs


### PR DESCRIPTION
Fix no rule to make target bzip-selinux-policy error during rpm build.

tendrl-bug-id: Tendrl/gluster-integration#421
Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>