### PR TITLE
Save brick partition information.

### DIFF
--- a/tendrl/gluster_integration/objects/brick/__init__.py
+++ b/tendrl/gluster_integration/objects/brick/__init__.py
@@ -8,6 +8,7 @@ class Brick(objects.BaseObject):
         brick_dir,
         name=None,
         devices=None,
+        partitions=None,
         brick_path=None,
         mount_path=None,
         node_id=None,
@@ -37,6 +38,7 @@ class Brick(objects.BaseObject):
         super(Brick, self).__init__(*args, **kwargs)
 
         self.devices = devices
+        self.partitions = partitions
         self.name = name
         self.node_id = node_id
         self.fqdn = fqdn

--- a/tendrl/gluster_integration/objects/definition/gluster.yaml
+++ b/tendrl/gluster_integration/objects/definition/gluster.yaml
@@ -368,9 +368,12 @@ namespace.gluster:
           uuid: 242f6190-9b37-11e6-950d-a24fc0d9649d
           help: Create gluster brick for gluster volume
       attrs:
-        disk:
-          help: the underlying disk for the device
-          type: String
+        devices:
+          help: the underlying devices for the brick
+          type: List
+        partitions:
+          help: the underlying partitions for the brick
+          type: List
         name:
           help: name of the brick
           type: String

--- a/tendrl/gluster_integration/sds_sync/brick_device_details.py
+++ b/tendrl/gluster_integration/sds_sync/brick_device_details.py
@@ -48,6 +48,11 @@ def update_brick_device_details(brick_name, brick_path, devicetree):
         d.path
     ) for d in device.ancestors if d.isDisk and not d.parents]
 
+    # partitions needed for calculating io stats.
+    partitions = [str(
+        d.path
+    ) for d in device.ancestors if d.type == "partition"]
+
     if device.type in ("lvmthinlv", "lvmlv"):
         lv = device.name
         if hasattr(device, "pool"):
@@ -60,6 +65,7 @@ def update_brick_device_details(brick_name, brick_path, devicetree):
         brick_name.split(":_")[-1],
         name=brick_name,
         devices=disks,
+        partitions=partitions,
         mount_path=mount_point,
         lv=lv,
         vg=vg,


### PR DESCRIPTION
This patch adds a new attribute for brick object
for storing the brick's partition information.
As its needed for calculating io stats.

tendrl-bug-id: Tendrl/gluster-integration#425
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>