### PR TITLE
Handle ignored native events properly.

### DIFF
--- a/tendrl/gluster_integration/message/callback.py
+++ b/tendrl/gluster_integration/message/callback.py
@@ -383,7 +383,7 @@ class Callback(object):
         native_event = NS.gluster.objects.NativeEvents(
             context,
             message=message,
-            severity="warning",
+            severity="info",
             current_value="georep_checkpoint_completed",
             alert_notify=True
         )

--- a/tendrl/gluster_integration/message/gluster_native_message_handler.py
+++ b/tendrl/gluster_integration/message/gluster_native_message_handler.py
@@ -32,9 +32,10 @@ class GlusterNativeMessageHandler(gevent.greenlet.Greenlet):
                     function = getattr(self.callback, callback_function_name)
                 except AttributeError:
                     # tendrl does not handle this perticular event hence ignore
-                    pass
+                    return "Event Ignored"
                 event_handler = gevent.spawn(function, gluster_event)
                 event_handler.join()
+                return "OK"
 
     def _setup_gluster_native_message_reciever(self):
         service = svc.Service("glustereventsd")


### PR DESCRIPTION
gluster native events that are being ignored by
gluster integration are not handled correctly, this
is causing an exception in event listener. Which in
turn is leading to an `500 internal server error` in
glusterfs events.log

tendrl-bug-id: Tendrl/gluster-integration#433
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>