### PR TITLE
Add flow to update brick status as stopped.

### DIFF
--- a/tendrl/gluster_integration/flows/update_brick_status/__init__.py
+++ b/tendrl/gluster_integration/flows/update_brick_status/__init__.py
@@ -1,0 +1,23 @@
+from tendrl.commons import flows
+from tendrl.commons.utils import log_utils as logger
+
+
+class UpdateBrickStatus(flows.BaseFlow):
+    def run(self):
+        logger.log(
+            "info",
+            NS.publisher_id,
+            {"message": "starting flow for updating brick status"}
+        )
+        super(UpdateBrickStatus, self).run()
+        node = self.parameters.get("Node.fqdn")
+        cluster_id = self.parameters.get("TendrlContext.integration_id")
+        status = self.parameters.get("Brick.status")
+        self.update_brick_status(node, cluster_id, status)
+
+    def update_brick_status(self, node, cluster_id, status):
+        bricks = NS.gluster.objects.Brick(fqdn=node).load_all()
+        for brick in bricks:
+            brick.status = status
+            brick.save()
+        return

--- a/tendrl/gluster_integration/objects/brick/__init__.py
+++ b/tendrl/gluster_integration/objects/brick/__init__.py
@@ -5,7 +5,7 @@ class Brick(objects.BaseObject):
     def __init__(
         self,
         fqdn,
-        brick_dir,
+        brick_dir=None,
         name=None,
         devices=None,
         partitions=None,

--- a/tendrl/gluster_integration/objects/definition/gluster.yaml
+++ b/tendrl/gluster_integration/objects/definition/gluster.yaml
@@ -26,6 +26,20 @@ namespace.gluster:
       type: Create
       uuid: 1951e821-7aa9-4a91-8183-e73bc8275b8e
       version: 1
+    UpdateBrickStatus:
+      tags:
+       - "tendrl/integration/$TendrlContext.integration_id"
+      help: "Update brick status as down"
+      enabled: true
+      inputs:
+        mandatory:
+          - TendrlContext.integration_id
+          - Node.fqdn
+          - Brick.status
+      run: gluster.flows.UpdateBrickStatus
+      type: Update
+      uuid: 8ff1c072-ee08-4afb-bbb3-106ee188b0af
+      version: 1
     CreateBrick:
       tags:
        - "provisioner/$TendrlContext.integration_id"

--- a/tendrl/gluster_integration/sds_sync/__init__.py
+++ b/tendrl/gluster_integration/sds_sync/__init__.py
@@ -590,7 +590,7 @@ def sync_volumes(volumes, index, vol_options):
                     'volume%s.brick%s.is_arbiter' % (index, b_index)
                 ),
             )
-            brick.save(ttl=SYNC_TTL)
+            brick.save()
             # sync brick device details
             brick_device_details.\
                 update_brick_device_details(


### PR DESCRIPTION
This patch adds a new flow UpdateBrickStatus
that updates the status of bricks of a given
node as "Stopped". This flow is invoked for
nodes that are down.

tendrl-bug-id: Tendrl/monitoring-integration#169
Signed-off-by: Darshan N <darshan.n.2024@gmail.com>