### PR TITLE
Collect inode usage details for volume

### DIFF
--- a/tendrl/gluster_integration/objects/definition/gluster.yaml
+++ b/tendrl/gluster_integration/objects/definition/gluster.yaml
@@ -961,6 +961,24 @@ namespace.gluster:
         quorum_status:
           help: "Quorum status"
           type: String
+        usable_capacity:
+          help: "total capacity of the volume"
+          type: int
+        used_capacity:
+          help: "used capacity of the volume"
+          type: int
+        pcnt_used:
+          help: "percentage of space used in volume"
+          type: int
+        total_inode_capacity:
+          help: "total inode"
+          type: int
+        used_inode_capacity:
+          help: "inode used"
+          type: int
+        pcnt_inode_used:
+          help: "inode used percentage"
+          type: int
         profiling_enabled:
           help: Whether profiling is enabled
           type: String

--- a/tendrl/gluster_integration/objects/volume/__init__.py
+++ b/tendrl/gluster_integration/objects/volume/__init__.py
@@ -25,6 +25,9 @@ class Volume(objects.BaseObject):
         usable_capacity=None,
         used_capacity=None,
         pcnt_used=None,
+        total_inode_capacity=None,
+        used_inode_capacity=None,
+        pcnt_inode_used=None,
         profiling_enabled=None,
         client_count=None,
         rebal_estimated_time=None,
@@ -56,6 +59,9 @@ class Volume(objects.BaseObject):
         self.usable_capacity = usable_capacity
         self.used_capacity = used_capacity
         self.pcnt_used = pcnt_used
+        self.total_inode_capacity = total_inode_capacity
+        self.used_inode_capacity = used_inode_capacity
+        self.pcnt_inode_used = pcnt_inode_used
         self.profiling_enabled = profiling_enabled
         self.client_count = client_count
         self.rebal_estimated_time = rebal_estimated_time

--- a/tendrl/gluster_integration/sds_sync/__init__.py
+++ b/tendrl/gluster_integration/sds_sync/__init__.py
@@ -88,14 +88,14 @@ class GlusterIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
                     )
                 )
                 raise ex
-        
+
         _sleep = 0
         while not self._complete.is_set():
             if _sleep > 5:
                 _sleep = int(NS.config.data.get("sync_interval", 10))
             else:
                 _sleep += 1
-                
+
             try:
                 try:
                     NS._int.wclient.write(

--- a/tendrl/gluster_integration/sds_sync/utilization.py
+++ b/tendrl/gluster_integration/sds_sync/utilization.py
@@ -33,6 +33,9 @@ def sync_utilization_details(volumes):
             volume.usable_capacity = int(util_det['total'])
             volume.used_capacity = int(util_det['used'])
             volume.pcnt_used = str(util_det['pcnt_used'])
+            volume.total_inode_capacity = int(util_det['total_inode'])
+            volume.used_inode_capacity = int(util_det['used_inode'])
+            volume.pcnt_inode_used = str(util_det['pcnt_inode_used'])
             volume.save()
             cluster_used_capacity += volume.used_capacity
             cluster_usable_capacity += volume.usable_capacity

--- a/tendrl/gluster_integration/sds_sync/vol_utilization.py
+++ b/tendrl/gluster_integration/sds_sync/vol_utilization.py
@@ -34,12 +34,18 @@ def showVolumeUtilization(vname):
     # used size in KB
     used_size = volumeCapacity['sizeUsed'] / BYTES_IN_KB
     vol_utilization = (used_size / total_size) * 100
+    used_inode = data.f_files - data.f_ffree
+    total_inode = data.f_files
+    pcnt_inode_used = (float(used_inode) / total_inode) * 100
     print (json.dumps(
         {
             'total': total_size,
             'free': free_size,
             'used': used_size,
-            'pcnt_used': vol_utilization
+            'pcnt_used': vol_utilization,
+            'total_inode': total_inode,
+            'used_inode': used_inode,
+            'pcnt_inode_used': pcnt_inode_used
         }
     ))
 


### PR DESCRIPTION
Currently volume inode usage details are not
collected. This patch takes care of that by
adding attributes to volume object that hold
inode usage info. This is being collected
through libgfapi.

tendrl-bug-id: Tendrl/gluster-integration#481
Signed-off-by: Darshan N <darshan.n.2024@gmail.com>