### PR TITLE
Handle remove brick correctly when subvolume number shifts

### DIFF
--- a/tendrl/gluster_integration/message/callback.py
+++ b/tendrl/gluster_integration/message/callback.py
@@ -9,6 +9,7 @@
 
 import etcd
 
+from tendrl.commons.utils import etcd_utils
 from tendrl.commons.utils import log_utils as logger
 from tendrl.commons.utils import monitoring_utils
 from tendrl.commons.utils import time_utils
@@ -655,6 +656,10 @@ class Callback(object):
             )
         except etcd.EtcdKeyNotFound:
             pass
+        
+        _trigger_sync_key = 'clusters/%s/_sync_now' % NS.tendrl_context.integration_id
+        etcd_utils.write(_trigger_sync_key, 'true')
+        etcd_utils.refresh(_trigger_sync_key, self.sync_interval)
 
     def volume_remove_brick_commit(self, event):
         self.volume_remove_brick_force(event)


### PR DESCRIPTION
As part of remove brick handler we are deleting all the brick
related information, so that next sync takes care of updating
the correct info

tendrl-bug-id: Tendrl/gluster-integration#494
Signed-off-by: Darshan N <darshan.n.2024@gmail.com>