### PR TITLE
Handle peer reject event correctly

### DIFF
--- a/tendrl/gluster_integration/message/callback.py
+++ b/tendrl/gluster_integration/message/callback.py
@@ -208,9 +208,9 @@ class Callback(object):
         native_event.save()
 
     def unknown_peer(self, event):
-        context = "unknown_peer|" + event['message']['peer']
+        context = "unknown_peer|" + event['message']['peer'].split(":")[0]
         message = "Peer {0} has moved to unknown state in cluster {1}".format(
-            event['message']['peer'],
+            event['message']['peer'].split(":")[0],
             NS.tendrl_context.integration_id
         )
         native_event = NS.gluster.objects.NativeEvents(
@@ -368,9 +368,9 @@ class Callback(object):
         native_event.save()
 
     def peer_reject(self, event):
-        context = "peer_reject|" + event['message']['peer']
+        context = "peer_reject|" + event['message']['peer'].split(":")[0]
         message = "Peer: {0} is rejected in cluster {1}".format(
-            event['message']['peer'],
+            event['message']['peer'].split(":")[0],
             NS.tendrl_context.integration_id
         )
         native_event = NS.gluster.objects.NativeEvents(


### PR DESCRIPTION
peer reject event gives peer name along with a number
appended to it. This is handled correctly by this patch

tendrl-bug-id: Tendrl/gluster-integration#514
Signed-off-by: Darshan N <darshan.n.2024@gmail.com>