### PR TITLE
Invoke job to delete dashboard on peer_detach

### DIFF
--- a/tendrl/gluster_integration/message/callback.py
+++ b/tendrl/gluster_integration/message/callback.py
@@ -455,9 +455,10 @@ class Callback(object):
         )
         native_event.save()
 
-    def peer_disconnect(self, event):
+    def peer_detach(self, event):
+        time.sleep(self.sync_interval)
         job_id = monitoring_utils.update_dashboard(
-            event['message']['peer'],
+            event['message']['host'],
             RESOURCE_TYPE_PEER,
             NS.tendrl_context.integration_id,
             "delete"


### PR DESCRIPTION
This patch changes the invocation of dashboard
deletion flow from peer disconnect to peer detach.
As peer detach is the user triggered action

tendrl-bug-id: Tendrl/gluster-integration#516
Signed-off-by: Darshan N <darshan.n.2024@gmail.com>