### PR TITLE
Add ttl to brick status attribute.

### DIFF
--- a/tendrl/gluster_integration/objects/brick/__init__.py
+++ b/tendrl/gluster_integration/objects/brick/__init__.py
@@ -1,4 +1,5 @@
 from tendrl.commons import objects
+from tendrl.commons.utils import etcd_utils
 
 
 class Brick(objects.BaseObject):
@@ -76,7 +77,12 @@ class Brick(objects.BaseObject):
             _volume = NS.gluster.objects.Volume(vol_id=self.vol_id)
             _volume.invalidate_hash()
 
-        return super(Brick, self).save(update, ttl)
+        super(Brick, self).save(update)
+        status = self.value + "/status"
+        if ttl:
+            etcd_utils.refresh(status, ttl)
+
+        return
 
     def render(self):
         self.value = self.value.format(

--- a/tendrl/gluster_integration/sds_sync/__init__.py
+++ b/tendrl/gluster_integration/sds_sync/__init__.py
@@ -630,7 +630,7 @@ def sync_volumes(volumes, index, vol_options):
                     'volume%s.brick%s.is_arbiter' % (index, b_index)
                 ),
             )
-            brick.save()
+            brick.save(ttl=SYNC_TTL)
             # sync brick device details
             brick_device_details.\
                 update_brick_device_details(
@@ -639,7 +639,8 @@ def sync_volumes(volumes, index, vol_options):
                         'volume%s.brick%s.path' % (
                             index, b_index)
                     ],
-                    devicetree
+                    devicetree,
+                    SYNC_TTL
                 )
 
             # Sync the brick client details

--- a/tendrl/gluster_integration/sds_sync/brick_device_details.py
+++ b/tendrl/gluster_integration/sds_sync/brick_device_details.py
@@ -26,7 +26,7 @@ def get_brick_source_and_mount(brick_path):
     return out.split("\n")[-1].split()
 
 
-def update_brick_device_details(brick_name, brick_path, devicetree):
+def update_brick_device_details(brick_name, brick_path, devicetree, sync_ttl):
     mount_source, mount_point = get_brick_source_and_mount(brick_path)
     if not mount_source or not mount_point:
         logger.log(
@@ -74,4 +74,4 @@ def update_brick_device_details(brick_name, brick_path, devicetree):
         size=size
     )
 
-    brick.save()
+    brick.save(ttl=sync_ttl)


### PR DESCRIPTION
Add ttl to brick status attribute. Because if all the
nodes in the cluster goes down, the status will remain
as up and the same info will be displayed in dashboard.
To avoid this we set ttl, so thet dashboard can clearly
indicate the staleness of the field

tendrl-bug-id: Tendrl/gluster-integration#525
Signed-off-by: Darshan N <darshan.n.2024@gmail.com>