### PR TITLE
Set first_sync_done once first sync gets over for cluster

### DIFF
--- a/tendrl/gluster_integration/sds_sync/__init__.py
+++ b/tendrl/gluster_integration/sds_sync/__init__.py
@@ -283,7 +283,13 @@ class GlusterIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
                     _cluster = _cluster.load()
                     _cluster.status = ""
                     _cluster.last_sync = str(tendrl_now())
-                    _cluster.is_managed = "yes"
+                    # Mark the first sync done flag
+                    _cnc = NS.tendrl.objects.ClusterNodeContext(
+                        node_id=NS.node_context.node_id
+                    ).load()
+                    if _cnc.first_sync_done in [None, "no"]:
+                        _cnc.first_sync_done = "yes"
+                        _cnc.save()
                     _cluster.save()
                     # Initialize alert count
                     try:


### PR DESCRIPTION
Instead of setting cluster.is_managed post sync, now set the field
first_sync_done only for the first time. This makes sure import
cluster flow gets completed only once all the storages nodes report
their first sync done.

tendrl-bug-id: Tendrl/commons#829
Signed-off-by: Shubhendu <shtripat@redhat.com>