### PR TITLE
volname is not required in start/stop profiling calls

### DIFF
--- a/tendrl/gluster_integration/objects/definition/gluster.yaml
+++ b/tendrl/gluster_integration/objects/definition/gluster.yaml
@@ -672,7 +672,6 @@ namespace.gluster:
           inputs:
             mandatory:
               - Volume.vol_id
-              - Volume.volname
           name: start volume profiling
           run: gluster.objects.Volume.atoms.StartProfiling
           type: Start
@@ -683,7 +682,6 @@ namespace.gluster:
           inputs:
             mandatory:
               - Volume.vol_id
-              - Volume.volname
           name: stop volume profiling
           run: gluster.objects.Volume.atoms.StopProfiling
           type: Stop


### PR DESCRIPTION
Signed-off-by: Shubhendu <shtripat@redhat.com>