### PR TITLE
Populating brick details correctly when peer hostname and brick hostname not match

### DIFF
--- a/tendrl/gluster_integration/sds_sync/__init__.py
+++ b/tendrl/gluster_integration/sds_sync/__init__.py
@@ -2,6 +2,7 @@ import blivet
 import json
 import re
 import subprocess
+import socket
 import threading
 import time
 
@@ -581,8 +582,8 @@ def sync_volumes(volumes, index, vol_options, sync_ttl):
             hostname = volumes[
                 'volume%s.brick%s.hostname' % (index, b_index)
             ]
-            if (NS.node_context.fqdn != hostname) and (
-                hostname not in network_ip):
+            if socket.gethostbyname(NS.node_context.fqdn) != \
+                    socket.gethostbyname(hostname):
                 b_index += 1
                 continue
             sub_vol_size = (int(

--- a/tendrl/gluster_integration/tests/test_sds_sync.py
+++ b/tendrl/gluster_integration/tests/test_sds_sync.py
@@ -5,6 +5,7 @@ import mock
 from mock import MagicMock
 from mock import patch
 import os
+import socket
 
 from tendrl.commons.objects import BaseObject
 from tendrl.commons.objects import node_context
@@ -33,8 +34,12 @@ def read(param):
 @patch.object(BaseObject, "hash_compare_with_central_store")
 @patch.object(event_utils, "emit_event")
 @patch.object(etcd_utils, "refresh")
-def test_sync_volumes(refresh, emit_event, compare, save, load, blivet):
+@patch.object(socket, 'gethostbyname')
+def test_sync_volumes(
+    get_host, refresh, emit_event, compare, save, load, blivet
+):
     init()
+    get_host.return_value = "127.0.0.1"
     refresh.return_value = True
     compare.return_value = True
     save.return_value = True


### PR DESCRIPTION


tendrl-bug-id: Tendrl/gluster-integration#609

Signed-off-by: Gowthamshanmugasundaram <gshanmug@redhat.com>