### PR TITLE
Changed to log the message as info if profile flag setting errors out

### DIFF
--- a/tendrl/gluster_integration/flows/enable_disable_volume_profiling/__init__.py
+++ b/tendrl/gluster_integration/flows/enable_disable_volume_profiling/__init__.py
@@ -60,11 +60,12 @@ class EnableDisableVolumeProfiling(flows.BaseFlow):
             ).run()
             if err != "" or rc != 0:
                 logger.log(
-                    "error",
+                    "info",
                     NS.publisher_id,
                     {
-                        "message": "%s profiling failed for volume: %s" %
-                        (action, volume.name)
+                        "message": "%s profiling failed for volume: %s."
+                        " Error: %s" %
+                        (action, volume.name, err)
                     },
                     job_id=self.parameters["job_id"],
                     flow_id=self.parameters["flow_id"]
@@ -78,7 +79,7 @@ class EnableDisableVolumeProfiling(flows.BaseFlow):
                 volume.save()
         if len(failed_vols) > 0:
             logger.log(
-                "error",
+                "info",
                 NS.publisher_id,
                 {
                     "message": "%s profiling failed for "


### PR DESCRIPTION
In case profiling is already enabled for a volume, enable command
fails for the same. In the flow these are logged as errors in task.
Changed the logic to log the messages and info as its actually not
a failure.

tendrl-bug-id: Tendrl/gluster-integration#631
Bugzilla-id: https://bugzilla.redhat.com/1577228
Signed-off-by: Shubhendu <shtripat@redhat.com>