### PR TITLE
Multiple peer connected events when new peer probe is done in managed cluster

### DIFF
--- a/tendrl/gluster_integration/sds_sync/__init__.py
+++ b/tendrl/gluster_integration/sds_sync/__init__.py
@@ -157,7 +157,7 @@ class GlusterIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
                                 current_status = peers[
                                     'peer%s.connected' % index
                                 ]
-                                if stored_peer_status != "" and \
+                                if stored_peer_status and \
                                     current_status != stored_peer_status:
                                     msg = (
                                         "Peer %s in cluster %s "


### PR DESCRIPTION
When new peer probe is done then all nodes raises peer connected info
event, so multiple events are displayed in UI. As per logic in
https://github.com/Tendrl/node-agent/pull/817 first non-info alert
raised then it will start comparing with an old alert to avoid duplicate
events but here actually info alert is raised first, so node-agent handler
does not have any old alert to avoid duplicate. And also we have a check to
avoid first info alert but it is wrong None == "" won't match.
I have corrected the logic here.

bugzilla: 1579937
tendrl-bug-id: Tendrl/gluster-integration#648

Signed-off-by: GowthamShanmugasundaram <gshanmug@redhat.com>