### PR TITLE
Creating native message handler object after integration_id found

### DIFF
--- a/tendrl/gluster_integration/manager/__init__.py
+++ b/tendrl/gluster_integration/manager/__init__.py
@@ -34,8 +34,6 @@ def main():
 
     NS.state_sync_thread = sds_sync.GlusterIntegrationSdsSyncStateThread()
 
-    NS.message_handler_thread = GlusterNativeMessageHandler()
-
     while NS.tendrl_context.integration_id is None or \
         NS.tendrl_context.integration_id == "":
         logger.log(
@@ -57,6 +55,9 @@ def main():
             NS.tendrl_context.integration_id
         }
     )
+    # Creating object form GlusterNativeMessageHandler
+    # After integration_id found
+    NS.message_handler_thread = GlusterNativeMessageHandler()
 
     NS.gluster.definitions.save()
     NS.gluster.config.save()


### PR DESCRIPTION
Inside message handler constructor we are finding cluster_name
using integration_id, if it before called integration_id found then
it will raise alert with None

tendrl-bug-id: Tendrl/gluster-integration#662
bugzilla: 1588440

Signed-off-by: GowthamShanmugasundaram <gshanmug@redhat.com>