### PR TITLE
Volume alert raised with volume name None

### DIFF
--- a/tendrl/gluster_integration/sds_sync/__init__.py
+++ b/tendrl/gluster_integration/sds_sync/__init__.py
@@ -282,9 +282,11 @@ class GlusterIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
                     ).load_all() or []
                     volumes = []
                     for volume in all_volumes:
-                        if not str(volume.deleted).lower() == "true" or \
+                        if not str(volume.deleted).lower() == "true" and \
                             volume.current_job.get('status', '') \
-                            in ['', 'finished', 'failed']:
+                            in ['', 'finished', 'failed'] and \
+                            volume.vol_id not in [None, ''] and \
+                            volume.name not in [None, '']:
                             # only for first sync refresh volume TTL
                             # It will increase TTL based on no.of volumes
                             if _cnc.first_sync_done in [None, "no", ""]:
@@ -292,7 +294,7 @@ class GlusterIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
                                     volume.value,
                                     SYNC_TTL + VOLUME_TTL
                                 )
-                                volumes.append(volume)
+                            volumes.append(volume)
                     cluster_status.sync_cluster_status(
                         volumes, SYNC_TTL + VOLUME_TTL
                     )


### PR DESCRIPTION
It is one more corner case problem, the problem is we
down all storage nodes and after volume are deleted by
TTL then we are starting all the nodes, what is happening
all storage nodes are pushing volume_rebalance data into
etcd before we decide provisioner. now volume entry present
with rebalance directory but there are no details about
volume because volume details are populated by provisioner
only. but provisioner is decided in-between of execution
then global details are executed before volume details
populate. so alert raised with name None.

tendrl-bug-id: Tendrl/gluster-integration#667
bugzilla: 1595295

Signed-off-by: GowthamShanmugasundaram <gshanmug@redhat.com>