### PR TITLE
Invoke volume utilization calculation as subprocess

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,8 @@ setup(
         ],
     entry_points={
         'console_scripts': [
-            'tendrl-gluster-integration = tendrl.gluster_integration.manager:main'
+            'tendrl-gluster-integration = tendrl.gluster_integration.manager:main',
+            'tendrl-gluster-vol-utilization = tendrl.gluster_integration.sds_sync.vol_utilization:main'
         ]
     },
     include_package_data=True,

--- a/tendrl/gluster_integration/sds_sync/__init__.py
+++ b/tendrl/gluster_integration/sds_sync/__init__.py
@@ -250,7 +250,7 @@ class GlusterIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
                             # SYNC_TTL + (no.volumes) * 20 +
                             # (no.of.bricks) * 10 + 160
                             if index > 1:
-                                volume_count = index -1
+                                volume_count = index - 1
                                 # When all nodes are down we are updating all
                                 # volumes are down, node status TTL is 160,
                                 # So make sure volumes are present in etcd

--- a/tendrl/gluster_integration/sds_sync/utilization.py
+++ b/tendrl/gluster_integration/sds_sync/utilization.py
@@ -1,11 +1,15 @@
+import json
+import os
+import subprocess
+
 from tendrl.commons.utils import log_utils as logger
-from tendrl.gluster_integration.sds_sync.vol_utilization import \
-    showVolumeUtilization
 
 
 def sync_utilization_details(volumes):
     cluster_used_capacity = 0
     cluster_usable_capacity = 0
+    volnames = ''
+    voldict = {}
     for volume in volumes:
         if volume.status != "Started":
             logger.log(
@@ -17,28 +21,56 @@ def sync_utilization_details(volumes):
                 }
             )
             continue
-        util_det = showVolumeUtilization(
-            volume.name
-        )
-        if util_det:
-            volume.usable_capacity = int(util_det['total'])
-            volume.used_capacity = int(util_det['used'])
-            volume.pcnt_used = str(util_det['pcnt_used'])
-            volume.total_inode_capacity = int(util_det['total_inode'])
-            volume.used_inode_capacity = int(util_det['used_inode'])
-            volume.pcnt_inode_used = str(util_det['pcnt_inode_used'])
-            volume.save()
-            cluster_used_capacity += volume.used_capacity
-            cluster_usable_capacity += volume.usable_capacity
+        volnames += volume.name + ','
+        voldict[volume.name] = volume
+
+    # IMPORTANT: This calculation of volume utilization is being done
+    # through a subprocess call intentionally and should not not be
+    # changed to in process call. This is done due to memory leak issues
+    # with gfapi (which is used underneath this tool). Keep this logic
+    # as is
+    cmd = subprocess.Popen(
+        "tendrl-gluster-vol-utilization %s" % volnames,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=open(os.devnull, "r"),
+        close_fds=True
+    )
+    out = ''
+    try:
+        out, err = cmd.communicate()
+        if err == '':
+            util_det = json.loads(out)
+            for k, v in util_det.iteritems():
+                volume = voldict[k]
+                volume.usable_capacity = int(v['total'])
+                volume.used_capacity = int(v['used'])
+                volume.pcnt_used = str(v['pcnt_used'])
+                volume.total_inode_capacity = int(v['total_inode'])
+                volume.used_inode_capacity = int(v['used_inode'])
+                volume.pcnt_inode_used = str(v['pcnt_inode_used'])
+                volume.save()
+                cluster_used_capacity += volume.used_capacity
+                cluster_usable_capacity += volume.usable_capacity
         else:
             logger.log(
                 "error",
                 NS.publisher_id,
                 {
                     "message": "Error getting utilization of "
-                    "volume: %s" % (volume.name)
+                    "volumes %s" % volnames
                 }
             )
+    except(KeyError, TypeError, ValueError):
+        logger.log(
+            "error",
+            NS.publisher_id,
+            {
+                "message": "Error getting utilization of "
+                "volumes %s . err: %s" % (volnames, out)
+            }
+        )
     cluster_pcnt_used = 0
     if cluster_usable_capacity > 0:
         cluster_pcnt_used = (

--- a/tendrl/gluster_integration/tests/test_volume_utilization.py
+++ b/tendrl/gluster_integration/tests/test_volume_utilization.py
@@ -9,6 +9,14 @@ from tendrl.gluster_integration.sds_sync import utilization
 
 
 @mock.patch(
+    'subprocess.Popen.communicate',
+    mock.Mock(return_value=('{"vol1": {"total": "20000", "used": "5000",\
+        "pcnt_used": "25", "total_inode": "100", "used_inode": "20",\
+        "pcnt_inode_used": "20"}, "vol2": {"total": "20000", "used": "5000",\
+        "pcnt_used": "25", "total_inode": "100", "used_inode": "20",\
+        "pcnt_inode_used": "20"}}', ""))
+)
+@mock.patch(
     'tendrl.gluster_integration.objects.volume.Volume.save',
     mock.Mock(return_value=None)
 )
@@ -24,24 +32,13 @@ from tendrl.gluster_integration.sds_sync import utilization
     'tendrl.commons.objects.BaseObject.__init__',
     mock.Mock(return_value=None)
 )
-@mock.patch.object(utilization, 'showVolumeUtilization')
-def test_sync_volume_utilization_details_with_started_volume(vol_util):
-    vol_util.return_value = (
-        {"total": "20000",
-         "used": "5000",
-         "pcnt_used": "25",
-         "total_inode": "100",
-         "used_inode": "20",
-         "pcnt_inode_used": "20"
-         }
-    )
+def test_sync_volume_utilization_details_with_started_volume():
     setattr(NS, "publisher_id", "gluster-integration")
     setattr(NS, "gluster", maps.NamedDict())
     NS.gluster["objects"] = maps.NamedDict()
     obj = importlib.import_module(
         'tendrl.gluster_integration.objects.utilization'
     )
-    obj.showVolumeUtilization = mock.MagicMock()
     for obj_cls in inspect.getmembers(obj, inspect.isclass):
         NS.gluster.objects["Utilization"] = obj_cls[1]
     volume = Volume(
@@ -69,6 +66,14 @@ def test_sync_volume_utilization_details_with_started_volume(vol_util):
 
 
 @mock.patch(
+    'subprocess.Popen.communicate',
+    mock.Mock(return_value=('{"vol1": {"total": "20000", "used": "5000",\
+        "pcnt_used": "25", "total_inode": "100", "used_inode": "20",\
+        "pcnt_inode_used": "20"}, "vol2": {"total": "20000", "used": "5000",\
+        "pcnt_used": "25", "total_inode": "100", "used_inode": "20",\
+        "pcnt_inode_used": "20"}}', ""))
+)
+@mock.patch(
     'tendrl.gluster_integration.objects.volume.Volume.save',
     mock.Mock(return_value=None)
 )
@@ -84,17 +89,7 @@ def test_sync_volume_utilization_details_with_started_volume(vol_util):
     'tendrl.commons.objects.BaseObject.__init__',
     mock.Mock(return_value=None)
 )
-@mock.patch.object(utilization, 'showVolumeUtilization')
-def test_sync_volume_utilization_details_with_started_volume1(vol_util):
-    vol_util.return_value = (
-        {"total": "20000",
-         "used": "5000",
-         "pcnt_used": "25",
-         "total_inode": "100",
-         "used_inode": "20",
-         "pcnt_inode_used": "20"
-         }
-    )
+def test_sync_volume_utilization_details_with_started_volume1():
     setattr(NS, "publisher_id", "gluster-integration")
     setattr(NS, "gluster", maps.NamedDict())
     NS.gluster["objects"] = maps.NamedDict()


### PR DESCRIPTION
There seems to be some meory leaks in gfapi and due to that if we
make in-memory calls to gfapi, the memory utilization on the nodes
keeps increasing slowly. If we make subprocess call this increase would
be eventual and no overall increase happens to the memory utilization
of the node.

tendrl-bug-id: Tendrl/gluster-integration#681
bugzilla: 1599987
Signed-off-by: Shubhendu <shtripat@redhat.com>