### PR TITLE
Adding integration_id in GeoReplicationSession object

### DIFF
--- a/tendrl/gluster_integration/objects/definition/gluster.yaml
+++ b/tendrl/gluster_integration/objects/definition/gluster.yaml
@@ -248,6 +248,9 @@ namespace.gluster:
         session_status:
           help: "aggregated status of geo-replication session"
           type: String
+        integration_id:
+          help: "integration id"
+          type: String
       enabled: true
       value: clusters/$TendrlContext.integration_id/Volumes/$Volume.vol_id/GeoReplicationSessions/$GeoReplicationPair.session_id
       list: clusters/$TendrlContext.integration_id/Volumes/$Volume.vol_id/GeoReplicationSessions

--- a/tendrl/gluster_integration/objects/geo_replication_session/__init__.py
+++ b/tendrl/gluster_integration/objects/geo_replication_session/__init__.py
@@ -17,6 +17,7 @@ class GeoReplicationSession(objects.BaseObject):
         session_id=None,
         session_status=None,
         pairs=None,
+        integration_id=None,
         *args,
         **kwargs
     ):
@@ -25,13 +26,15 @@ class GeoReplicationSession(objects.BaseObject):
         self.vol_id = vol_id
         self.session_id = session_id
         self.session_status = session_status
+        self.integration_id = integration_id or \
+            NS.tendrl_context.integration_id
         if pairs:
             self.pairs = pairs
         self.value = 'clusters/{0}/Volumes/{1}/GeoRepSessions/{2}'
 
     def render(self):
         self.value = self.value.format(
-            NS.tendrl_context.integration_id,
+            self.integration_id or NS.tendrl_context.integration_id,
             self.vol_id,
             self.session_id
         )


### PR DESCRIPTION
This is changed based on common's GeoReplicationSession object

tendrl-bug-id: Tendrl/gluster-integration#686
bugzilla: 1603175

Signed-off-by: GowthamShanmugasundaram <gshanmug@redhat.com>