### PR TITLE
Cluster import is failing when no block device is in LVM type

### DIFF
--- a/tendrl/gluster_integration/sds_sync/brick_utilization.py
+++ b/tendrl/gluster_integration/sds_sync/brick_utilization.py
@@ -59,10 +59,12 @@ def get_lvs():
             {"message": str(err)}
         )
         return None
-    out = out.split('\n')
-    lst = map(lambda x: dict(x),
-              map(lambda x: [e.split('=') for e in x],
-                  map(lambda x: x.strip().split('$'), out)))
+    lst = {}
+    if out != '':
+        out = out.split('\n')
+        lst = map(lambda x: dict(x),
+                  map(lambda x: [e.split('=') for e in x],
+                      map(lambda x: x.strip().split('$'), out)))
 
     d = {}
     for i in lst:


### PR DESCRIPTION
bugzilla: 1683603
tendrl-bug-id: Tendrl/gluster-integration#713

Signed-off-by: GowthamShanmugasundaram <gshanmug@redhat.com>